### PR TITLE
don't transform Qt::Key names to camelcase

### DIFF
--- a/src/bindgen/generator/crystal.cr
+++ b/src/bindgen/generator/crystal.cr
@@ -75,7 +75,10 @@ module Bindgen
         puts "@[Flags]" if enumeration.origin.flags?
         code_block "enum", enumeration.name, ":", type_name do
           enumeration.origin.values.each do |name, value|
-            puts "#{name.camelcase} = #{value}"
+            unless enumeration.path_name == "Qt::Key"
+              name = name.camelcase
+            end
+            puts "#{name} = #{value}"
           end
         end
       end


### PR DESCRIPTION
Fix for #6 