### PR TITLE
LLVM 6 support

### DIFF
--- a/clang/include/clang_type_name.hpp
+++ b/clang/include/clang_type_name.hpp
@@ -63,7 +63,11 @@ SOFTWARE.
  //
  //===----------------------------------------------------------------------===//
 
+ #if LLVM_VERSION_MAJOR >= 6
+ #include "clang/AST/QualTypeNames.h"
+ #else
  #include "clang/Tooling/Core/QualTypeNames.h"
+ #endif
  #include "clang/AST/DeclTemplate.h"
  #include "clang/AST/DeclarationName.h"
  #include "clang/AST/GlobalDecl.h"
@@ -438,7 +442,7 @@ namespace ClangTypeName {
                                 bool WithGlobalNsPrefix) {
    // In case of myType* we need to strip the pointer first, fully
    // qualify and attach the pointer once again.
-   if (isa<PointerType>(QT.getTypePtr())) {
+   if (isa<clang::PointerType>(QT.getTypePtr())) {
      // Get the qualifiers.
      Qualifiers Quals = QT.getQualifiers();
      QT = getFullyQualifiedType(QT->getPointeeType(), Ctx, WithGlobalNsPrefix);

--- a/clang/src/type_helper.cpp
+++ b/clang/src/type_helper.cpp
@@ -1,6 +1,5 @@
 #include "type_helper.hpp"
 
-#include "clang/Tooling/Core/QualTypeNames.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclTemplate.h"


### PR DESCRIPTION
1. `QualTypeNames.h` moved from `Tooling/Core` to `AST`;
2. Change `PointerType` -> `clang::PointerType` fixes compilation warning `include/clang_type_name.hpp:445:12: error: reference to 'PointerType' is ambiguous`;
3. Include of `QualTypeNames.h` removed from `type_helper.cpp` because it will be included by `clang_type_name.hpp` 6 lines later.