### PR TITLE
WIP: Remove Tempfile as it was removed in crystal .27

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: bindgen
-version: 0.6.2
-crystal: 0.25.0
+version: 0.6.3
+crystal: 0.27.0
 
 description: C/C++/Qt binding and wrapper generator
 

--- a/spec/bindgen/config_reader/loader_spec.cr
+++ b/spec/bindgen/config_reader/loader_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 private def with_dependency(content)
   name = "loader_spec_#{rand 1..1_000_000}"
-  full_path = "#{Tempfile.dirname}/#{name}.yml"
+  full_path = "#{Dir.tempdir}/#{name}.yml"
   File.write(full_path, content)
   yield name, full_path
 
@@ -12,13 +12,13 @@ end
 
 describe Bindgen::ConfigReader::Loader do
   subject = Bindgen::ConfigReader::Loader.new
-  base_file = "#{Tempfile.dirname}/the_root.yml" # Fake path
+  base_file = "#{Dir.tempdir}/the_root.yml" # Fake path
 
   describe "#load" do
     context "with .yml suffix" do
       it "loads the dependency" do
         with_dependency "Okay" do |name|
-          subject.load(base_file, "#{name}.yml").should eq({ "Okay", "#{Tempfile.dirname}/#{name}.yml" })
+          subject.load(base_file, "#{name}.yml").should eq({ "Okay", "#{Dir.tempdir}/#{name}.yml" })
         end
       end
 
@@ -50,7 +50,7 @@ describe Bindgen::ConfigReader::Loader do
     context "without .yml suffix" do
       it "loads the dependency" do
         with_dependency "Okay" do |name|
-          subject.load(base_file, name).should eq({ "Okay", "#{Tempfile.dirname}/#{name}.yml" })
+          subject.load(base_file, name).should eq({ "Okay", "#{Dir.tempdir}/#{name}.yml" })
         end
       end
 

--- a/spec/clang/spec_helper.cr
+++ b/spec/clang/spec_helper.cr
@@ -12,7 +12,7 @@ end
 # key-word arguments are checked for equality in the returned JSON document.
 # The check allows partial document comparisons.
 def clang_tool(cpp_code, arguments, **checks)
-  file = Tempfile.new("bindgen-clang-test")
+  file = File.tempfile("bindgen-clang-test")
   file.puts(cpp_code)
   file.flush
 

--- a/src/bindgen/library.cr
+++ b/src/bindgen/library.cr
@@ -1,7 +1,6 @@
 # Main require-file of bindgen - Except for the CLI tool.
 # Require this file if you want to use bindgen as library.
 
-require "tempfile"
 require "json"
 require "yaml"
 require "set"

--- a/src/bindgen/parser/runner.cr
+++ b/src/bindgen/parser/runner.cr
@@ -49,7 +49,7 @@ module Bindgen
       private def generate_source_file
         result = nil
 
-        Tempfile.open("bindgen") do |file|
+        File.tempfile("bindgen") do |file|
           @config.files.each do |path|
             path = Util.template(path, replacement: nil)
             file.puts %{#include #{path.inspect}}

--- a/src/bindgen/parser/runner.cr
+++ b/src/bindgen/parser/runner.cr
@@ -49,7 +49,7 @@ module Bindgen
       private def generate_source_file
         result = nil
 
-        File.tempfile("bindgen") do |file|
+        File.tempfile "bindgen" do |file|
           @config.files.each do |path|
             path = Util.template(path, replacement: nil)
             file.puts %{#include #{path.inspect}}

--- a/src/bindgen/processor/instantiate_containers.cr
+++ b/src/bindgen/processor/instantiate_containers.cr
@@ -5,7 +5,7 @@ module Bindgen
     # specific `Call`s, like `Crystal` or `Cpp`.
     class InstantiateContainers < Base
       # Name of the "standard" built-in integer C++ type.  Required for the
-      # generated `#size` method, and `#unsafe_at` of sequential containers.
+      # generated `#size` method, and `#unsafe_fetch` of sequential containers.
       CPP_INTEGER_TYPE = "int"
 
       # Base class of sequential containers
@@ -176,7 +176,7 @@ module Bindgen
           class_name: klass_name,
           arguments: [ idx_arg ],
           return_type: var_type,
-          crystal_name: "unsafe_at", # Will implement `Indexable#unsafe_at`
+          crystal_name: "unsafe_fetch", # Will implement `Indexable#unsafe_fetch`
         )
       end
 

--- a/tool.sh
+++ b/tool.sh
@@ -32,7 +32,7 @@ else
   exec crystal run "$SOURCE_FILE" -- --chdir "$OLD_PWD" $@
 fi
 
-echo "If you see this, something went horribly wrong."
-echo "  1) Make sure you have crystal installed"
-echo "  2) Make sure `crystal` is in your \$PATH"
+echo 'If you see this, something went horribly wrong.'
+echo '  1) Make sure you have crystal installed'
+echo '  2) Make sure `crystal` is in your $PATH'
 exit 127


### PR DESCRIPTION
Use `File.tempfile` instead, works pretty much just the same. 

Hopefully this'll resolve https://github.com/Papierkorb/qt5.cr/issues/21.