### PR TITLE
Use llvm-config for LLVM & clang configuration

### DIFF
--- a/clang/Makefile
+++ b/clang/Makefile
@@ -1,10 +1,14 @@
 IGNORE   := $(shell crystal run find_clang.cr > Makefile.variables)
 include Makefile.variables
 
+LLVM_LIBS := $(shell $(LLVM_CONFIG) --system-libs --libs core)
+LLVM_INCLUDE_DIR := $(shell $(LLVM_CONFIG) --includedir)
+LLVM_LDFLAGS  := $(shell $(LLVM_CONFIG) --ldflags)
 # NOTE: No -ltinfo on OSX
-LIBS     := $(CLANG_LIBS) -ldl -pthread -lz -lcurses -ltinfo -lpcre
+CLANG_LIBS := -lclang -lclangAST -lclangBasic -lclangFrontend -lclangLex -lclangTooling -lclangDriver -lclangParse -lclangASTMatchers
+LIBS     := $(LLVM_LIBS) $(CLANG_LIBS) -ldl -pthread -lz -lcurses -ltinfo -lpcre
 DEFINES  := -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS
-CXXFLAGS := -std=c++11 $(DEFINES) -Iinclude $(CLANG_INCLUDES)
+CXXFLAGS := -std=c++11 $(DEFINES) -Iinclude -I$(LLVM_INCLUDE_DIR)
 
 HEADERS  := $(wildcard include/*.hpp)
 SOURCES  := $(wildcard src/*.cpp)
@@ -23,6 +27,6 @@ build/%.o: src/%.cpp $(HEADERS)
 	$(CXX) -c -o $@ $< $(CXXFLAGS)
 
 $(BINARY): $(OBJECTS)
-	$(CXX) -o $(BINARY) $(OBJECTS) $(LIBS)
+	$(CXX) -o $(BINARY) $(OBJECTS) $(LIBS) $(LLVM_LDFLAGS)
 
 .PHONY: clean


### PR DESCRIPTION
This allowed me to run bindgen on Fedora 29 with llvm & clang 5.0 using:
$ dnf install llvm5.0-devel clang5.0-devel llvm5.0-libs clang5.0-libs
$ LLVM_CONFIG=/usr/bin/llvm-config-5.0-64 VERBOSE=1 CLANG_BINARY=/bin/clang++ ./lib/bindgen/tool.sh xcb.yml
`llvm-config` is used by Crystal's build process itself, so I think it should be pretty cross-platform, but let me know if it's not the case. All in all, I think configuration should become a bit simpler this way.
I'll update the documentation too, meanwhile please let me know what you think.
