### PR TITLE
final fix for issue #6

### DIFF
--- a/src/bindgen/generator/crystal.cr
+++ b/src/bindgen/generator/crystal.cr
@@ -75,7 +75,7 @@ module Bindgen
         puts "@[Flags]" if enumeration.origin.flags?
         code_block "enum", enumeration.name, ":", type_name do
           enumeration.origin.values.each do |name, value|
-            puts "#{name.camelcase} = #{value}"
+            puts "#{name} = #{value}"
           end
         end
       end

--- a/src/bindgen/processor/enums.cr
+++ b/src/bindgen/processor/enums.cr
@@ -37,10 +37,6 @@ module Bindgen
             unless key[0]?.try(&.uppercase?) && key[1]?.try(&.lowercase?)
               key = key.downcase.camelcase
             end
-          else
-            if key[0]?.try(&.lowercase?)
-              key = key.capitalize
-            end
           end
 
           {key, value}


### PR DESCRIPTION
Some notes:
+ method `#capitalize` will turn `Dead_A` to `Dead_a`, so removed;
+ doing `#{name.camelcase}` in src/bindgen/generator/crystal.cr is useless,
  as it will be done in Enums#camelcase_fields