### PR TITLE
Clang 10 Support

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -65,11 +65,11 @@ if(NOT EXISTS ${shards_bin})
 endif()
 
 # Execute find_clang.cr
-message(STATUS "Execute find_clang.cr")
+message(STATUS "Run: crystal find_clang.cr -- --clang ${CMAKE_CXX_COMPILER} --quiet")
 
 execute_process(
         COMMAND ${crystal_bin} ${PROJECT_SOURCE_DIR}/find_clang.cr -- --clang ${CMAKE_CXX_COMPILER} --quiet
-        COMMAND_ECHO STDOUT
+        # COMMAND_ECHO STDOUT
         ERROR_VARIABLE find_clang_error
         OUTPUT_FILE ${PROJECT_SOURCE_DIR}/Makefile.variables
 )
@@ -79,16 +79,44 @@ if(NOT ${find_clang_error} STREQUAL "")
 endif()
 
 # Execute find_clang.cr for clang_libs
+message(STATUS "Run: crystal find_clang.cr -- --clang-libs --clang ${CMAKE_CXX_COMPILER} --quiet")
 execute_process(
-        COMMAND ${crystal_bin} ${PROJECT_SOURCE_DIR}/find_clang.cr -- --clang ${CMAKE_CXX_COMPILER} --clang-libs --quiet
-        COMMAND_ECHO STDOUT
+        COMMAND ${crystal_bin} ${PROJECT_SOURCE_DIR}/find_clang.cr -- --clang-libs --clang ${CMAKE_CXX_COMPILER} --quiet
+        # COMMAND_ECHO STDOUT
         OUTPUT_VARIABLE clang_libs
         ERROR_VARIABLE find_clang_error
 )
-
 if(NOT ${find_clang_error} STREQUAL "")
   message(FATAL_ERROR ${find_clang_error})
 endif()
+
+
+if("${llvm_libs}" STREQUAL "")
+  message(WARNING "Unable to find llvm libs. Will run command manually" )
+
+  # NOTE: This execute_process will use `llvm-config --libs all` to gather the libs
+  # message(STATUS "Run: ${llvm_config_bin} --libs all")
+  # execute_process(
+  #         COMMAND bash -c "${llvm_config_bin} --libs all | sed -E 's/\-l/;/g' | sed -E 's/ //g'"
+  #         # COMMAND_ECHO STDOUT
+  #         # ERROR_VARIABLE find_clang_error
+  #         OUTPUT_VARIABLE llvm_libs
+  #         OUTPUT_STRIP_TRAILING_WHITESPACE
+  # )
+
+  # Execute find_clang.cr for clang_libs
+  message(STATUS "Run: crystal find_clang.cr -- --llvm-libs --clang ${CMAKE_CXX_COMPILER} --quiet")
+  execute_process(
+          COMMAND ${crystal_bin} ${PROJECT_SOURCE_DIR}/find_clang.cr -- --llvm-libs --clang ${CMAKE_CXX_COMPILER} --quiet
+          # COMMAND_ECHO STDOUT
+          OUTPUT_VARIABLE llvm_libs
+          ERROR_VARIABLE find_clang_error
+  )
+
+endif()
+
+
+
 
 ######################
 # Configure sources

--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 project(bindgen-clang)
 
-set(CMAKE_CXX_STANDARD_11)
-
 ######################
 # LLVM Setup
 ######################
@@ -17,15 +15,22 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 string(REGEX MATCH "^([0-9]+)" LLVM_VER ${LLVM_PACKAGE_VERSION})
 message(STATUS "LLVM Major version: ${LLVM_VER}")
 
+# If LLVM 10+ change std version
+if(LLVM_VER GREATER_EQUAL 10)
+  message(STATUS "Setting std version: c++14")
+  set(CMAKE_CXX_STANDARD_14)
+else()
+  set(CMAKE_CXX_STANDARD_11)
+endif()
+
 # Add llvm version definition
 add_definitions(-D__LLVM_VERSION_${LLVM_VER})
-
 
 # Find the LLVM clang++ path
 message(STATUS "LLVM Tools Dir: ${LLVM_TOOLS_BINARY_DIR}")
 
 find_program(clang_bin "clang++" PATHS: ${LLVM_TOOLS_BINARY_DIR})
-message(STATUS "Found clang bin: ${clang_bin}")
+# message(STATUS "Found clang bin: ${clang_bin}")
 set(CMAKE_CXX_COMPILER ${clang_bin})
 message(STATUS "Using clang++ exec: ${CMAKE_CXX_COMPILER}")
 
@@ -40,11 +45,9 @@ include_directories(${LLVM_INCLUDE_DIRS})
 message(STATUS "Add LLVM definitions: ${LLVM_DEFINITIONS}")
 add_definitions(${LLVM_DEFINITIONS})
 
-
 # Find the libraries that correspond to the LLVM components
 # that we wish to use
 llvm_map_components_to_libnames(llvm_libs all)
-
 
 ######################
 # Gather info
@@ -62,19 +65,30 @@ if(NOT EXISTS ${shards_bin})
 endif()
 
 # Execute find_clang.cr
+message(STATUS "Execute find_clang.cr")
+
 execute_process(
-        COMMAND ${crystal_bin} ${PROJECT_SOURCE_DIR}/find_clang.cr
+        COMMAND ${crystal_bin} ${PROJECT_SOURCE_DIR}/find_clang.cr -- --clang ${CMAKE_CXX_COMPILER} --quiet
+        COMMAND_ECHO STDOUT
+        ERROR_VARIABLE find_clang_error
         OUTPUT_FILE ${PROJECT_SOURCE_DIR}/Makefile.variables
-        ERROR_QUIET
 )
+
+if(NOT ${find_clang_error} STREQUAL "")
+  message(FATAL_ERROR ${find_clang_error})
+endif()
 
 # Execute find_clang.cr for clang_libs
 execute_process(
-        COMMAND ${crystal_bin} ${PROJECT_SOURCE_DIR}/find_clang.cr -- --clang-libs
+        COMMAND ${crystal_bin} ${PROJECT_SOURCE_DIR}/find_clang.cr -- --clang ${CMAKE_CXX_COMPILER} --clang-libs --quiet
+        COMMAND_ECHO STDOUT
         OUTPUT_VARIABLE clang_libs
-        ERROR_QUIET
+        ERROR_VARIABLE find_clang_error
 )
 
+if(NOT ${find_clang_error} STREQUAL "")
+  message(FATAL_ERROR ${find_clang_error})
+endif()
 
 ######################
 # Configure sources
@@ -91,7 +105,7 @@ add_executable(bindgen ${source_files})
 target_link_libraries(bindgen ${clang_libs})
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   message(STATUS "CLang Libs: ${clang_libs}")
-endif ()
+endif()
 
 # Link against LLVM libraries
 target_link_libraries(bindgen ${llvm_libs})

--- a/clang/find_clang.cr
+++ b/clang/find_clang.cr
@@ -120,6 +120,7 @@ def shell_split(line : String)
       end
     when '"' # String marker
       in_string = !in_string
+    else
     end
   end
 
@@ -168,6 +169,7 @@ while index < flags.size
     l = flags[index][2..-1]
     l += "/" if l !~ /\/$/
     system_libs << l
+  else
   end
 
   index += 1

--- a/clang/find_clang.cr
+++ b/clang/find_clang.cr
@@ -291,4 +291,5 @@ if !llvm_config_binary.nil? && File.exists?(llvm_config_binary)
     .gsub(/\s+/, " ")
   puts "LLVM_LD_FLAGS := " + `#{llvm_config_binary} --ldflags`.chomp
     .gsub(/\s+/, " ")
+  puts "LLVM_LIBS := " + get_lib_args(llvm_libs).join(" ")
 end


### PR DESCRIPTION
This is for #28 and also fixes a few issues i saw with the cmake script:

- added cli parsing to find_clang.cr
- fixed issue where llvm_libs were blank
- fixed an issue where find_clang would fail silently in cmake

I added support for a `--clang` flag to the `find_clang.cr` script, which will allow definition of which clang to use. This fixed a lot of problems since cmake can pass it.