### PR TITLE
fix for error "#unsafe_fetch(index : Int)` must be implemented ..."

### DIFF
--- a/builtin_types.yml
+++ b/builtin_types.yml
@@ -15,6 +15,7 @@ short: { binding_type: Int16, kind: Struct, builtin: true }
 int: { binding_type: Int32, kind: Struct, builtin: true }
 unsigned: { binding_type: UInt32, kind: Struct, builtin: true }
 "unsigned int": { binding_type: UInt32, kind: Struct, builtin: true }
+_Int: { binding_type: Int, crystal_type: Int, cpp_type: int, kind: Struct, builtin: true }
 
 # Long types
 "long": { binding_type: "LibC::Long", kind: Struct, builtin: true }

--- a/src/bindgen/call_builder/crystal_wrapper.cr
+++ b/src/bindgen/call_builder/crystal_wrapper.cr
@@ -62,9 +62,16 @@ module Bindgen
           # type.
           result = call.result unless call.origin.any_constructor?
 
+          arguments = call.arguments
+          if call.name == "unsafe_fetch" && arguments.size == 1 && arguments[0].name == "index"
+            idx_type = Parser::Type.builtin_type("_Int")
+            idx_arg = Parser::Argument.new("index", idx_type)
+            arguments = Crystal::Pass.new(@db).arguments_to_wrapper([idx_arg])
+          end
+
           head_line = method.prototype(
             name: call.name,
-            arguments: call.arguments,
+            arguments: arguments,
             result: result,
             static: call.origin.static_method?,
             abstract: call.origin.pure?,


### PR DESCRIPTION
This change forces method argument for `unsafe_fetch` to be `Int` type.