### PR TITLE
Always start enum value name with uppercase letter

### DIFF
--- a/src/bindgen/processor/enums.cr
+++ b/src/bindgen/processor/enums.cr
@@ -37,6 +37,8 @@ module Bindgen
             unless key[0]?.try(&.uppercase?) && key[1]?.try(&.lowercase?)
               key = key.downcase.camelcase
             end
+          elsif key[0]?.try(&.lowercase?)
+            key = key[0].upcase + key[1..]
           end
 
           {key, value}


### PR DESCRIPTION
Ensure that enum value name is started with uppercase letter.
Before this change code could produce invalid crystal code.
Sorry that I didn't fix this at once.