### PR TITLE
Add type tags for block parameter disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ dependencies:
       * [Generator step](#generator-step)
    * [Processors](#processors)
       * [AutoContainerInstantiation](#autocontainerinstantiation)
+      * [BlockOverloads](#blockoverloads)
       * [CopyStructs](#copystructs)
       * [CppWrapper](#cppwrapper)
       * [CrystalBinding](#crystalbinding)
@@ -248,6 +249,27 @@ containers: # At the top-level of the config
     # instantiations: # Can be added, but doesn't need to be.
 ```
 
+## `BlockOverloads`
+
+* **Kind**: Refining, but ran after generation processors!
+* **Run after**: `CrystalWrapper`, `Qt`
+* **Run before**: No specific dependency
+
+Adds type parameters to ambiguous Crystal methods that take a single block
+argument, so that these methods can be overloaded by passing the parameter types
+of that argument to the method.  `Qt` needs it for several signal connection
+methods.
+
+```crystal
+cb = Qt::ComboBox.new
+cb.on_activated(Int32) do |index| # Type argument added by this processor
+  puts "Int32 overload selected: #{index}"
+end
+cb.on_activated(String) do |text| # Type argument added by this processor
+  puts "String overload selected: #{text}"
+end
+```
+
 ## `CopyStructs`
 
 * **Kind**: Refining
@@ -402,7 +424,7 @@ function-like macros are silently skipped.
 
 * **Kind**: Refining
 * **Run after**: No specific dependency
-* **Run before**: No specific dependency
+* **Run before**: `BlockOverloads`
 
 Adds Qt specific behaviour:
 
@@ -430,6 +452,7 @@ Checks are as follows:
 * Name of methods are valid
 * Enumerations have at least one constant
 * Flag-enumerations don't have `All` nor `None` constants
+* Crystal method overloads are unambiguous
 * Method arguments and result types are reachable
 * Variadic methods are directly bound
 * Alias targets are reachable
@@ -456,6 +479,7 @@ This is the recommended processor order:
 processors:
   # ...
   - crystal_wrapper
+  - block_overloads
   - virtual_override
   - cpp_wrapper
   - crystal_binding

--- a/SPEC.md
+++ b/SPEC.md
@@ -272,11 +272,26 @@ second the connection method, which are then exposed as Crystal wrappers.
 * Emission method: `changed(one : Int32) : Void`
 * Connection method: `on_changed(&block : Int32 -> Void)`
 
-### §Q.1.1
+### §Q.1.1 Signal connection object
 
 The connection method returns an connection object, which responds to
 `#disconnect`.  Calling this method breaks the connection.  Subsequent calls to
 this method have no effect.
+
+### §Q.1.2 Overloaded signals
+
+An overload is defined for each signature of a connection method that may take
+different sets of parameters.  The overloads take the expected types of the
+signal parameters, as mandatory function arguments.  This only happens to
+overloaded signals; type arguments are not required for signals with unique
+signatures.
+
+* Given these signals:
+  * `void changed(int one)`
+  * `void changed(bool two)`
+* Connection methods:
+  * `on_changed(type1 : Int32.class, &block : Int32 -> Void)`
+  * `on_changed(type1 : Bool.class, &block : Bool -> Void)`
 
 ### §Q.2 QFlags
 

--- a/TEMPLATE.yml
+++ b/TEMPLATE.yml
@@ -42,6 +42,7 @@ processors:
   - enums # Add enums
   # Preliminary generation processors:
   - crystal_wrapper # Create Crystal wrappers
+  - block_overloads # Add type tags for block overloads
   - virtual_override # Allow overriding C++ virtual methods
   - cpp_wrapper # Create C++ <-> C wrappers
   - crystal_binding # Create `lib` bindings for the C wrapper

--- a/spec/integration/qt.cpp
+++ b/spec/integration/qt.cpp
@@ -12,9 +12,9 @@ struct QMetaObject {
 };
 
 struct QObject {
-  template< typename T, typename F >
-  static QMetaObject::Connection connect(void *ptr, T func, F delegate) {
-    delegate(); // Call back to Crystal
+  template< typename R, typename T, typename... Args, typename F >
+  static QMetaObject::Connection connect(void *ptr, R (T::*func)(Args...), F delegate) {
+    delegate(Args { }...); // Call back to Crystal
 
     return QMetaObject::Connection();
   }
@@ -30,6 +30,18 @@ public:
 
 signals:
   void stuffHappened() {
+    // Empty.
+  }
+
+  void overloaded(int x) {
+    // Empty.
+  }
+
+  void overloaded(bool y) {
+    // Empty.
+  }
+
+  void overloaded(int x, bool y) {
     // Empty.
   }
 

--- a/spec/integration/qt.yml
+++ b/spec/integration/qt.yml
@@ -7,6 +7,7 @@ processors:
   - cpp_wrapper
   - crystal_binding
   - crystal_wrapper
+  - block_overloads
   - sanity_check
 
 classes:

--- a/spec/integration/qt_spec.cr
+++ b/spec/integration/qt_spec.cr
@@ -15,6 +15,37 @@ describe "Qt-specific wrapper features" do
           called.should be_true
         end
 
+        context "overloaded signals" do
+          it "creates methods for each overload" do
+            subject = Test::SomeObject.new
+
+            overload = 0
+            subject.on_overloaded(Int32) do |_i|
+              _i.should be_a(Int32)
+              overload = 1
+            end
+            overload.should eq(1)
+            subject.on_overloaded(Bool) do |_b|
+              _b.should be_a(Bool)
+              overload = 2
+            end
+            overload.should eq(2)
+            subject.on_overloaded(Int32, Bool) do |_i, _b|
+              _i.should be_a(Int32)
+              _b.should be_a(Bool)
+              overload = 3
+            end
+            overload.should eq(3)
+
+            # check that tag-less overload isn't defined on Crystal
+            {{
+              Test::SomeObject.methods.select do |method|
+                method.name == "on_overloaded" && method.args.empty?
+              end.size
+            }}.should eq(0)
+          end
+        end
+
         context "private signals" do
           it "don't have an emission method" do
             {{ Test::SomeObject.methods.map(&.name.stringify) }}.includes?("private_signal").should be_false

--- a/spec/integration/qt_spec.cr
+++ b/spec/integration/qt_spec.cr
@@ -20,19 +20,19 @@ describe "Qt-specific wrapper features" do
             subject = Test::SomeObject.new
 
             overload = 0
-            subject.on_overloaded(Int32) do |_i|
-              _i.should be_a(Int32)
+            subject.on_overloaded(Int32) do |i|
+              i.should be_a(Int32)
               overload = 1
             end
             overload.should eq(1)
-            subject.on_overloaded(Bool) do |_b|
-              _b.should be_a(Bool)
+            subject.on_overloaded(Bool) do |b|
+              b.should be_a(Bool)
               overload = 2
             end
             overload.should eq(2)
-            subject.on_overloaded(Int32, Bool) do |_i, _b|
-              _i.should be_a(Int32)
-              _b.should be_a(Bool)
+            subject.on_overloaded(Int32, Bool) do |i, b|
+              i.should be_a(Int32)
+              b.should be_a(Bool)
               overload = 3
             end
             overload.should eq(3)

--- a/src/bindgen/call.cr
+++ b/src/bindgen/call.cr
@@ -105,6 +105,11 @@ module Bindgen
     class VariadicArgument < Argument
     end
 
+    # A type argument whose type is a metaclass (`T.class`).
+    # Only used for Crystal code to disambiguate block overloads.
+    class TypeArgument < Argument
+    end
+
     # A `Proc` argument.  May be a block.
     class ProcArgument < Argument
       # Is this a block argument?

--- a/src/bindgen/crystal/format.cr
+++ b/src/bindgen/crystal/format.cr
@@ -35,7 +35,11 @@ module Bindgen
           prefix = "&"
         end
 
-        "#{prefix}#{argument.name(arg, idx)} : #{typer.full arg}#{default}"
+        if arg.is_a?(Call::TypeArgument)
+          meta = ".class"
+        end
+
+        "#{prefix}#{argument.name(arg, idx)} : #{typer.full arg}#{meta}#{default}"
       end
 
       # Formats *arguments* as `type name, ...`.  If *binding* is `true`, treat

--- a/src/bindgen/processor/block_overloads.cr
+++ b/src/bindgen/processor/block_overloads.cr
@@ -1,0 +1,71 @@
+module Bindgen
+  module Processor
+    # Generates overloads for methods that accept a single block argument.
+    # Those methods are ambiguous because Crystal does not permit overloading
+    # through different type restrictions on the block; this processor rectifies
+    # this by requiring each overload to also specify the types of the block
+    # parameters.  For example, the following code
+    #
+    # ```
+    # def f(& : Int32 ->) end
+    # def f(& : Bool ->) end
+    # def f(& : Int32, Bool ->) end
+    # ```
+    #
+    # is transformed into
+    #
+    # ```
+    # def f(_type1_ : Int32.class, & : Int32 ->) end
+    # def f(_type1_ : Bool.class, & : Bool ->) end
+    # def f(_type1_ : Int32.class, _type2_ : Bool.class, & : Int32, Bool ->) end
+    # ```
+    #
+    # Unambiguous methods that accept block arguments are unaffected.
+    class BlockOverloads < Base
+      PLATFORM = Graph::Platform::Crystal
+
+      def visit_platform_specific(specific)
+        super if specific.platforms.includes?(PLATFORM)
+      end
+
+      def visit_class(klass)
+        methods_by_name = klass.nodes.compact_map do |node|
+          if method = node.as?(Graph::Method)
+            if call = method.calls[PLATFORM]?
+              # only select methods with a single block argument
+              if call.arguments.size == 1 && call.arguments.last.is_a?(Call::ProcArgument)
+                {method, call}
+              end
+            end
+          end
+        end.group_by {|_, call| call.name}
+
+        typer = Crystal::Typename.new(@db)
+
+        methods_by_name.each do |name, overloads|
+          next if overloads.size == 1
+          overloads.each do |method, call|
+            proc_type = call.arguments.last.as(Call::ProcArgument).type
+            proc_args = proc_type.template.not_nil!.arguments.skip(1) # ignore return type
+            arg_count = proc_args.size
+
+            proc_args.reverse_each.with_index do |proc_arg, i|
+              # generate unique parameter name in order
+              name = "_type#{arg_count - i}_"
+              type_name, _ = typer.wrapper(proc_arg)
+
+              call.arguments.unshift(Call::TypeArgument.new(
+                type: proc_arg.as(Parser::Type),
+                type_name: type_name,
+                name: name,
+                call: name,
+              ))
+            end
+          end
+        end
+
+        super
+      end
+    end
+  end
+end

--- a/src/bindgen/processor/block_overloads.cr
+++ b/src/bindgen/processor/block_overloads.cr
@@ -38,7 +38,7 @@ module Bindgen
               end
             end
           end
-        end.group_by {|_, call| call.name}
+        end.group_by { |_, call| call.name }
 
         typer = Crystal::Typename.new(@db)
 

--- a/src/bindgen/processor/sanity_check.cr
+++ b/src/bindgen/processor/sanity_check.cr
@@ -152,20 +152,18 @@ module Bindgen
       end
 
       # Checks if *args1* and *arg2* represent ambiguous method signatures.
-      # Does not check variadic arguments and default values yet.
+      # Does not check variadic arguments yet.
       private def ambiguous_signatures?(args1, args2)
-        if args1.size == args2.size
-          args1.zip(args2).all? do |arg1, arg2|
-            if arg1.is_a?(Call::Argument) && arg2.is_a?(Call::Argument)
-              arg1.type.equals_except_nil?(arg2.type)
-            elsif arg1.is_a?(Call::ProcArgument) && arg2.is_a?(Call::ProcArgument)
-              true # block arguments do not create overloads
-            else
-              false
-            end
+        return false unless args1.size == args2.size
+
+        args1.zip(args2).all? do |arg1, arg2|
+          if arg1.is_a?(Call::Argument) && arg2.is_a?(Call::Argument)
+            arg1.type.equals_except_nil?(arg2.type)
+          elsif arg1.is_a?(Call::ProcArgument) && arg2.is_a?(Call::ProcArgument)
+            true # block arguments do not create overloads
+          else
+            false
           end
-        else
-          false
         end
       end
 

--- a/src/bindgen/processor/sanity_check.cr
+++ b/src/bindgen/processor/sanity_check.cr
@@ -113,7 +113,7 @@ module Bindgen
               {method, call}
             end
           end
-        end.group_by {|_, call| call.name}
+        end.group_by { |_, call| call.name }
 
         methods_by_name.each do |name, overloads|
           overloads.each_combination(2, reuse: true) do |perm|

--- a/src/bindgen/processor/sanity_check.cr
+++ b/src/bindgen/processor/sanity_check.cr
@@ -115,8 +115,8 @@ module Bindgen
           end
         end.group_by {|_, call| call.name}
 
-        methods_by_name.each do |name, vs|
-          vs.each_combination(2, reuse: true) do |perm|
+        methods_by_name.each do |name, overloads|
+          overloads.each_combination(2, reuse: true) do |perm|
             method1, call1 = perm[0]
             method2, call2 = perm[1]
             if method1.origin.static_method? == method2.origin.static_method?


### PR DESCRIPTION
An attempt to fix #59, through a new `BlockOverloads` processor. For instance this is `Qt::ButtonGroup#on_button_toggled`, which has 2 overloads each taking two parameters in the block:

```crystal
module Qt
  # lib Binding is unmodified

  class ButtonGroup
    def on_button_toggled(_type1_ : AbstractButton.class, _type2_ : Bool.class, &_proc_ : Proc(AbstractButton, Bool, Void)) : SignalConnection
      SignalConnection.new(unwrap: Binding.bg_QButtonGroup_CONNECT_buttonToggled_CrystalProc_void_QAbstractButton_X_bool(self, BindgenHelper.wrap_proc(_proc_)))
    end
    
    def on_button_toggled(_type1_ : Int32.class, _type2_ : Bool.class, &_proc_ : Proc(Int32, Bool, Void)) : SignalConnection
      SignalConnection.new(unwrap: Binding.bg_QButtonGroup_CONNECT_buttonToggled_CrystalProc_void_int_bool(self, BindgenHelper.wrap_proc(_proc_)))
    end
  end
end

btn_group = Qt::ButtonGroup.new

btn_group.on_button_toggled(Int32, Bool) { |id, checked| typeof(id) }
btn_group.on_button_toggled(Int32, Bool, &->(id, checked) { typeof(id) })
# Int32

btn_group.on_button_toggled(Qt::AbstractButton, Bool) { |btn, checked| typeof(btn) }
# Qt::AbstractButton

btn_group.on_button_toggled { |id, checked| }
# Error: wrong number of arguments for 'Qt::ButtonGroup#on_button_toggled' (given 0, expected 2)
```

Similar transformations may be applied even for non-Qt bindings, as long as block arguments are emitted somewhere (that's why the code sits in a new processor rather than in `Qt`).

I have restricted this to methods that do not take non-block arguments, because I am unsure whether those type tags should be prepended at the start or inserted right before the block; the former resembles C++ function templates, while the latter places the tags closer to the block itself. Fortunately, all those ambiguous methods in the Qt bindings are precisely those `#on_SIGNAL` functions, which indeed take just the block argument.

`Bindgen::Call::TypeArgument` is there because I don't think `Argument` really supports this `_.class` usage. This *may* prove useful for function template instantiations in the future where type tags are similarly passed as regular arguments (`template <class> bool QVariant::canConvert() const` for example).