### PR TITLE
Fix CI for old CMake versions

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -16,7 +16,7 @@ string(REGEX MATCH "^([0-9]+)" LLVM_VER ${LLVM_PACKAGE_VERSION})
 message(STATUS "LLVM Major version: ${LLVM_VER}")
 
 # If LLVM 10+ change std version
-if(LLVM_VER GREATER_EQUAL 10)
+if(LLVM_VER GREATER 9)
   message(STATUS "Setting std version: c++14")
   set(CMAKE_CXX_STANDARD_14)
 else()


### PR DESCRIPTION
`GREATER_EQUAL` was introduced in CMake 3.7 but Travis is still using 3.5.1, so `GREATER` should be used instead.