### PR TITLE
CI: Fix "use of undeclared identifier 'nullptr'"

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -18,9 +18,9 @@ message(STATUS "LLVM Major version: ${LLVM_VER}")
 # If LLVM 10+ change std version
 if(LLVM_VER GREATER 9)
   message(STATUS "Setting std version: c++14")
-  set(CMAKE_CXX_STANDARD_14)
+  set(CMAKE_CXX_STANDARD 14)
 else()
-  set(CMAKE_CXX_STANDARD_11)
+  set(CMAKE_CXX_STANDARD 11)
 endif()
 
 # Add llvm version definition


### PR DESCRIPTION
`CMAKE_CXX_STANDARD_xx` -> `CMAKE_CXX_STANDARD xx`