### PR TITLE
VirtualOverride: only accept destructible base classes

### DIFF
--- a/src/bindgen/processor/virtual_override.cr
+++ b/src/bindgen/processor/virtual_override.cr
@@ -56,7 +56,7 @@ module Bindgen
 
       # If *klass* shall be sub-classed, or not.
       private def subclass?(klass) : Bool
-        return false unless klass.has_virtual_methods?
+        return false unless klass.has_virtual_methods? && klass.destructible?
         @db.try_or(klass.name, true, &.sub_class)
       end
 


### PR DESCRIPTION
VirtualOverride will fail if a class declares a private destructor. For example [this is what happens to QClipboard](https://godbolt.org/z/qTvP9q) when I tried to add it to qt5.cr:

```cpp
class QObject {
public:
    virtual ~QObject();
};

class QClipboard : public QObject {
private:
    explicit QClipboard(QObject *parent);
    ~QClipboard();
};

struct BgInherit_Clipboard : public QClipboard {
};
```

```
<source>:12:8: error: deleted function 'virtual BgInherit_Clipboard::~BgInherit_Clipboard()' overriding non-deleted function
   12 | struct BgInherit_Clipboard : public QClipboard {
      |        ^~~~~~~~~~~~~~~~~~~
<source>:9:5: note: overridden function is 'virtual QClipboard::~QClipboard()'
    9 |     ~QClipboard();
      |     ^
<source>:12:8: note: 'virtual BgInherit_Clipboard::~BgInherit_Clipboard()' is implicitly deleted because the default definition would be ill-formed:
   12 | struct BgInherit_Clipboard : public QClipboard {
      |        ^~~~~~~~~~~~~~~~~~~
<source>:12:8: error: 'virtual QClipboard::~QClipboard()' is private within this context
<source>:9:5: note: declared private here
    9 |     ~QClipboard();
      |     ^
```

Defining a destructor in the `BgInherit` struct will also fail:

```cpp
struct BgInherit_Clipboard : public QClipboard {
    ~BgInherit_Clipboard() { } // error: 'QClipboard::~QClipboard()' is private within this context
};
```

Having a private destructor usually means the API manages the lifetime of the instances and clients aren't supposed to create new instances, so there is no point in subclassing those classes anyway.