### PR TITLE
Generate property methods for accessible instance variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ dependencies:
       * [Functions](#functions)
       * [FunctionClass](#functionclass)
       * [Inheritance](#inheritance)
+      * [InstanceProperties](#instanceproperties)
       * [InstantiateContainers](#instantiatecontainers)
       * [Macros](#macros)
       * [Qt](#qt)
@@ -111,6 +112,7 @@ The following rules are automatically applied to all bindings:
 | Mapping C++ classes                              |         |
 |  +- Member methods                               | **YES** |
 |  +- Static methods                               | **YES** |
+|  +- Getters and setters for instance variables   | **YES** |
 |  +- Constructors                                 | **YES** |
 |  +- Overloaded operators                         |   TBD   |
 |  +- Conversion functions                         |   TBD   |
@@ -391,6 +393,14 @@ through configuration in the `functions:` map.
 Implements Crystal wrapper inheritance and adds `#as_X` conversion methods.
 Also handles abstract classes in that it adds an `Impl` class, so code can
 return instances to the (otherwise) abstract class.
+
+## `InstanceProperties`
+
+* **Kind**: Refining
+* **Run after**: No specific dependency
+* **Run before**: No specific dependency
+
+Generates getter and setter methods for instance members.
 
 ## `InstantiateContainers`
 

--- a/TEMPLATE.yml
+++ b/TEMPLATE.yml
@@ -36,6 +36,7 @@ processors:
   - copy_structs # Copy structures as marked
   - macros # Support for macro mapping
   - functions # Add non-class functions
+  - instance_properties # Add property methods for public instance members
   - filter_methods # Throw out filtered methods
   - extern_c # Directly bind to pure C functions
   - instantiate_containers # Actually instantiate containers

--- a/TEMPLATE.yml
+++ b/TEMPLATE.yml
@@ -432,6 +432,29 @@ types:
     # Defaults to `false`.
     copy_structure: true | false
 
+    # Whether to generate property methods for instance variables.  It may take
+    # a boolean or a hash:
+    # * `true`: Generate all methods with their default settings.
+    # * `false`: Disable all methods.
+    # * Hash: Each key is a regex pattern matching the names of the instance
+    #   variables, and the corresponding value controls the behaviour of the
+    #   matched variables.
+    # Defaults to `true`.  `copy_structure: true` will suppress the generation
+    # of property methods regardless of this setting.
+    instance_variables:
+      "^m_i(.*)$":
+        # Do not generate the getter(s) and setter(s) for the matched variables.
+        # Defaults to `false`.
+        ignore: true | false
+        # Optional: renames the property method(s).  Regex backreferences are
+        # supported.  Underscore transformation is applied after renaming.
+        # By default no renaming is applied.
+        rename: "\\1"
+        # Marks the instance variable(s) as nilable, allowing the property
+        # methods to use `nil`.  Only applied to pointer variables.
+        # Defaults to `false`.
+        nilable: true | false
+
     # Treat this type as built-in type in C++ and Crystal.
     # Defaults to `false`.
     builtin: true | false

--- a/spec/integration/instance_properties.cpp
+++ b/spec/integration/instance_properties.cpp
@@ -28,3 +28,22 @@ private:
   int x_priv;
   const int y_priv;
 };
+
+struct ConfigIgnoreAll {
+  const int a, b;
+};
+
+struct ConfigIgnore {
+  const int a, b;
+};
+
+struct ConfigRename {
+  const int aa, ab, bb;
+};
+
+struct ConfigNilable {
+  ConfigNilable() = default;
+
+  bool *bool_ptr;
+  Point *point_ptr;
+};

--- a/spec/integration/instance_properties.cpp
+++ b/spec/integration/instance_properties.cpp
@@ -38,7 +38,7 @@ struct ConfigIgnore {
 };
 
 struct ConfigRename {
-  const int aa, ab, bb;
+  const int m_iVar, m_iAnotherVar, x;
 };
 
 struct ConfigNilable {

--- a/spec/integration/instance_properties.cpp
+++ b/spec/integration/instance_properties.cpp
@@ -1,0 +1,30 @@
+struct Point {
+  Point(int x, int y) : x(x), y(y) { }
+
+  int x, y;
+};
+
+class Props {
+public:
+  Props(int x, int y) :
+    x_pub(x), y_pub(y),
+    x_prot(x + 100), y_prot(y + 100),
+    x_priv(x + 200), y_priv(y + 200)
+  {
+    (void)x_priv; // silence -Wunused-private-field
+    (void)y_priv;
+  }
+
+  int x_pub;
+  const int y_pub;
+  Point *position_ptr = new Point(12, 34);
+  Point position_val {13, 35};
+
+protected:
+  int x_prot;
+  const int y_prot;
+
+private:
+  int x_priv;
+  const int y_priv;
+};

--- a/spec/integration/instance_properties.yml
+++ b/spec/integration/instance_properties.yml
@@ -1,0 +1,13 @@
+<<: spec_base.yml
+
+processors:
+  - filter_methods
+  - instance_properties
+  - crystal_wrapper
+  - cpp_wrapper
+  - crystal_binding
+  - sanity_check
+
+classes:
+  Point: Point
+  Props: Props

--- a/spec/integration/instance_properties.yml
+++ b/spec/integration/instance_properties.yml
@@ -26,7 +26,7 @@ types:
       a: { ignore: true }
   ConfigRename:
     instance_variables:
-      "^a(.)$": { rename: "a_\\1" }
+      "^m_i(.*)$": { rename: "\\1" }
   ConfigNilable:
     instance_variables:
       ".*": { nilable: true }

--- a/spec/integration/instance_properties.yml
+++ b/spec/integration/instance_properties.yml
@@ -11,3 +11,22 @@ processors:
 classes:
   Point: Point
   Props: Props
+  ConfigIgnoreAll: ConfigIgnoreAll
+  ConfigIgnore: ConfigIgnore
+  ConfigRename: ConfigRename
+  ConfigNilable: ConfigNilable
+
+types:
+  Point:
+    instance_variables: true
+  ConfigIgnoreAll:
+    instance_variables: false
+  ConfigIgnore:
+    instance_variables:
+      a: { ignore: true }
+  ConfigRename:
+    instance_variables:
+      "^a(.)$": { rename: "a_\\1" }
+  ConfigNilable:
+    instance_variables:
+      ".*": { nilable: true }

--- a/spec/integration/instance_properties_spec.cr
+++ b/spec/integration/instance_properties_spec.cr
@@ -23,6 +23,13 @@ describe "C++ instance properties" do
           props = Test::Props.new(5, 8)
           props.x_pub.should eq(5)
           props.y_pub.should eq(8)
+
+          {% begin %}
+            {% method = Test::Props.methods.find &.name.== "x_pub" %}
+            {{ method.visibility }}.should eq(:public)
+            {% method = Test::Props.methods.find &.name.== "y_pub" %}
+            {{ method.visibility }}.should eq(:public)
+          {% end %}
         end
 
         it "is generated for protected members" do
@@ -63,6 +70,11 @@ describe "C++ instance properties" do
           props = Test::Props.new(5, 8)
           props.x_pub = 7
           props.x_pub.should eq(7)
+
+          {% begin %}
+            {% method = Test::Props.methods.find &.name.== "x_pub=" %}
+            {{ method.visibility }}.should eq(:public)
+          {% end %}
         end
 
         it "is generated for protected members" do

--- a/spec/integration/instance_properties_spec.cr
+++ b/spec/integration/instance_properties_spec.cr
@@ -1,0 +1,108 @@
+require "./spec_helper"
+
+describe "C++ instance properties" do
+  it "works" do
+    build_and_run("instance_properties") do
+      # expose private methods as public ones
+      class MyProps < Test::Props
+        def x_prot
+          super
+        end
+
+        def x_prot=(x)
+          super
+        end
+
+        def y_prot
+          super
+        end
+      end
+
+      context "getter methods" do
+        it "is generated for public members" do
+          props = Test::Props.new(5, 8)
+          props.x_pub.should eq(5)
+          props.y_pub.should eq(8)
+        end
+
+        it "is generated for protected members" do
+          props = MyProps.new(5, 8)
+          props.x_prot.should eq(105)
+          props.y_prot.should eq(108)
+
+          {% begin %}
+            {% method = Test::Props.methods.find &.name.== "x_prot" %}
+            {{ method.visibility }}.should eq(:private)
+            {% method = Test::Props.methods.find &.name.== "y_prot" %}
+            {{ method.visibility }}.should eq(:private)
+          {% end %}
+        end
+
+        it "is ignored for private members" do
+          {{ Test::Props.has_method?("x_priv") }}.should be_false
+          {{ Test::Props.has_method?("y_priv") }}.should be_false
+        end
+
+        it "supports pointer members" do
+          position = Test::Props.new(5, 8).position_ptr
+          position.should be_a(Test::Point)
+          position.x.should eq(12)
+          position.y.should eq(34)
+        end
+
+        it "supports class-type value members" do
+          position = Test::Props.new(5, 8).position_val
+          position.should be_a(Test::Point)
+          position.x.should eq(13)
+          position.y.should eq(35)
+        end
+      end
+
+       context "setter methods" do
+        it "is generated for public members" do
+          props = Test::Props.new(5, 8)
+          props.x_pub = 7
+          props.x_pub.should eq(7)
+        end
+
+        it "is generated for protected members" do
+          props = MyProps.new(5, 8)
+          props.x_prot = 7
+          props.x_prot.should eq(7)
+
+          {% begin %}
+            {% method = Test::Props.methods.find &.name.== "x_prot=" %}
+            {{ method.visibility }}.should eq(:private)
+          {% end %}
+        end
+
+        it "is ignored for private members" do
+          {{ Test::Props.has_method?("x_priv=") }}.should be_false
+        end
+
+        it "is ignored for const members" do
+          methods = {{ Test::Props.methods.map &.name.stringify }}
+          methods.includes?("y_pub=").should be_false
+          methods.includes?("y_prot=").should be_false
+          methods.includes?("y_priv=").should be_false
+        end
+
+        it "supports pointer members" do
+          props = Test::Props.new(5, 8)
+          props.position_ptr = Test::Point.new(60, 61)
+          got = props.position_ptr
+          got.x.should eq(60)
+          got.y.should eq(61)
+        end
+
+        it "supports class-type value members" do
+          props = Test::Props.new(5, 8)
+          props.position_val = Test::Point.new(60, 61)
+          got = props.position_val
+          got.x.should eq(60)
+          got.y.should eq(61)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/instance_properties_spec.cr
+++ b/spec/integration/instance_properties_spec.cr
@@ -116,11 +116,11 @@ describe "C++ instance properties" do
         end
 
         it "can rename property methods" do
-          {{ Test::ConfigRename.has_method?("a_a") }}.should be_true
-          {{ Test::ConfigRename.has_method?("aa") }}.should be_false
-          {{ Test::ConfigRename.has_method?("a_b") }}.should be_true
-          {{ Test::ConfigRename.has_method?("ab") }}.should be_false
-          {{ Test::ConfigRename.has_method?("bb") }}.should be_true
+          {{ Test::ConfigRename.has_method?("var") }}.should be_true
+          {{ Test::ConfigRename.has_method?("m_i_var") }}.should be_false
+          {{ Test::ConfigRename.has_method?("another_var") }}.should be_true
+          {{ Test::ConfigRename.has_method?("m_i_another_var") }}.should be_false
+          {{ Test::ConfigRename.has_method?("x") }}.should be_true
         end
 
         context "can mark a pointer member as nilable" do

--- a/spec/integration/instance_properties_spec.cr
+++ b/spec/integration/instance_properties_spec.cr
@@ -58,7 +58,7 @@ describe "C++ instance properties" do
         end
       end
 
-       context "setter methods" do
+      context "setter methods" do
         it "is generated for public members" do
           props = Test::Props.new(5, 8)
           props.x_pub = 7
@@ -101,6 +101,42 @@ describe "C++ instance properties" do
           got = props.position_val
           got.x.should eq(60)
           got.y.should eq(61)
+        end
+      end
+
+      context "YAML configuration" do
+        it "supports `instance_variables: false`" do
+          {{ Test::ConfigIgnoreAll.has_method?("a") }}.should be_false
+          {{ Test::ConfigIgnoreAll.has_method?("b") }}.should be_false
+        end
+
+        it "can ignore individual properties" do
+          {{ Test::ConfigIgnore.has_method?("a") }}.should be_false
+          {{ Test::ConfigIgnore.has_method?("b") }}.should be_true
+        end
+
+        it "can rename property methods" do
+          {{ Test::ConfigRename.has_method?("a_a") }}.should be_true
+          {{ Test::ConfigRename.has_method?("aa") }}.should be_false
+          {{ Test::ConfigRename.has_method?("a_b") }}.should be_true
+          {{ Test::ConfigRename.has_method?("ab") }}.should be_false
+          {{ Test::ConfigRename.has_method?("bb") }}.should be_true
+        end
+
+        context "can mark a pointer member as nilable" do
+          props = Test::ConfigNilable.new
+          bool = uninitialized Bool
+          point = Test::Point.new(3, 4)
+
+          props.bool_ptr = pointerof(bool)
+          props.bool_ptr.should eq(pointerof(bool))
+          props.bool_ptr = nil
+          props.bool_ptr.should eq(Pointer(Bool).null)
+
+          props.point_ptr = point
+          props.point_ptr.not_nil!.to_unsafe.should eq(point.to_unsafe)
+          props.point_ptr = nil
+          props.point_ptr.should eq(nil)
         end
       end
     end

--- a/src/bindgen/call_builder/crystal_wrapper.cr
+++ b/src/bindgen/call_builder/crystal_wrapper.cr
@@ -76,6 +76,7 @@ module Bindgen
             static: call.origin.static_method?,
             abstract: call.origin.pure?,
             protected: call.origin.protected?,
+            private: call.origin.private?,
           )
 
           %[#{head_line}\n] \

--- a/src/bindgen/configuration.cr
+++ b/src/bindgen/configuration.cr
@@ -33,6 +33,28 @@ module Bindgen
       end
     end
 
+    # Reads the table of instance variable configurations.  Additionally accepts
+    # `true` (use default settings) and `false` (ignore all members).
+    module InstanceVariablesConverter
+      private alias ValueType = TypeDatabase::InstanceVariableConfig::Collection
+
+      def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : ValueType
+        if node.is_a?(YAML::Nodes::Scalar)
+          case node.value
+          when "true"
+            ValueType.new
+          when "false"
+            { /.*/ => TypeDatabase::InstanceVariableConfig.new ignore: true }
+          else
+            node.raise "Expected Bool or Hash for instance_variables"
+          end
+        else
+          str_table = Hash(String, TypeDatabase::InstanceVariableConfig).new(ctx, node)
+          str_table.transform_keys(&->Regex.new(String))
+        end
+      end
+    end
+
     # Configuration of a generator, as given as value in `generators:`
     class Generator
       include YAML::Serializable

--- a/src/bindgen/cpp/method_name.cr
+++ b/src/bindgen/cpp/method_name.cr
@@ -27,7 +27,7 @@ module Bindgen
             name = class_name_for_new(method.class_name)
             @db.cookbook.constructor_name(method.name, name)
           end
-        when .member_method?, .signal?, .operator?
+        when .member_method?, .member_getter?, .member_setter?, .signal?, .operator?
           "#{self_var}->#{method.name}"
         when .static_method?
           if method.class_name == GLOBAL_SCOPE

--- a/src/bindgen/crystal/method.cr
+++ b/src/bindgen/crystal/method.cr
@@ -6,7 +6,11 @@ module Bindgen
       end
 
       # Builds the prototype ("first line") of a method.
-      def prototype(name, arguments, result = nil, static = false, abstract abstract_ = false, protected protected_ = false)
+      def prototype(
+        name, arguments, result = nil, static = false,
+        abstract abstract_ = false, protected protected_ = false,
+        private private_ = false
+      ) : String
         formatter = Format.new(@db)
         typer = Typename.new(@db)
         func_result = typer.full(result) if result
@@ -16,6 +20,7 @@ module Bindgen
         suffix = " : #{func_result}" if func_result
         name_prefix = "self." if static
         kind = "protected " if protected_
+        kind = "private " if private_
         kind += "abstract " if abstract_
 
         %[#{kind}def #{name_prefix}#{name}(#{func_args})#{suffix}]

--- a/src/bindgen/crystal/pass.cr
+++ b/src/bindgen/crystal/pass.cr
@@ -245,8 +245,7 @@ module Bindgen
         end
 
         if nilable
-          %[ptr = %\n] \
-          %[#{type_name}.new(unwrap: ptr) unless ptr.null?]
+          %[%.try {|ptr| #{type_name}.new(unwrap: ptr) unless ptr.null?}]
         else
           "#{type_name}.new(unwrap: %)"
         end

--- a/src/bindgen/crystal/pass.cr
+++ b/src/bindgen/crystal/pass.cr
@@ -170,8 +170,13 @@ module Bindgen
               ptr -= 1
             end
 
+            # Do not return types like `Bool*?` from the wrapper.
+            if rules.builtin && ptr > 0 && !is_ref
+              nilable = false
+            end
+
             if !rules.builtin && !is_constructor && !rules.converter && !rules.to_crystal && !in_lib && !rules.kind.enum?
-              template = wrapper_initialize_template(rules, type_name)
+              template = wrapper_initialize_template(rules, type_name, nilable)
             end
 
             is_ref, ptr = reconfigure_pass_type(rules.crystal_pass_by, is_ref, ptr)
@@ -231,7 +236,7 @@ module Bindgen
 
       # Returns the `Call::Result#conversion` template to turn a pointer into an
       # instance of *type_name* by using its `#initialize(unwrap: x)` method.
-      private def wrapper_initialize_template(rules, type_name)
+      private def wrapper_initialize_template(rules, type_name, nilable)
         # If the target type is abstract, use its `Impl` class instead.
         if klass = rules.graph_node.as?(Graph::Class)
           if impl = klass.wrap_class
@@ -239,7 +244,12 @@ module Bindgen
           end
         end
 
-        "#{type_name}.new(unwrap: %)"
+        if nilable
+          %[ptr = %\n] \
+          %[#{type_name}.new(unwrap: ptr) unless ptr.null?]
+        else
+          "#{type_name}.new(unwrap: %)"
+        end
       end
     end
   end

--- a/src/bindgen/parser/class.cr
+++ b/src/bindgen/parser/class.cr
@@ -71,6 +71,14 @@ module Bindgen
         Util.mangle_type_name(@name)
       end
 
+      # Yields each instance field defined in this class.  Does not include
+      # fields from base classes.
+      def each_field
+        @fields.each do |field|
+          yield field
+        end
+      end
+
       # Constructs a method destroying an instance of this class.
       def destructor_method : Method
         Parser::Method.new(

--- a/src/bindgen/parser/method.cr
+++ b/src/bindgen/parser/method.cr
@@ -11,6 +11,8 @@ module Bindgen
         CopyConstructor
         Destructor
         MemberMethod
+        MemberGetter
+        MemberSetter
         StaticMethod
         Operator
 
@@ -68,7 +70,8 @@ module Bindgen
         method
       end
 
-      delegate constructor?, copy_constructor?, member_method?, static_method?, signal?, operator?, destructor?, to: @type
+      delegate constructor?, copy_constructor?, member_method?, member_getter?,
+        member_setter?, static_method?, signal?, operator?, destructor?, to: @type
       delegate public?, protected?, private?, to: @access
 
       def_equals_and_hash @type, @name, @className, @access, @arguments, @firstDefaultArgument, @returnType, @isConst, @isVirtual, @isPure, @isExternC
@@ -253,6 +256,10 @@ module Bindgen
           else
             name # Normal method
           end
+        when .member_getter?
+          name
+        when .member_setter?
+          name + "="
         when .constructor?
           "initialize"
         when .copy_constructor?
@@ -392,6 +399,8 @@ module Bindgen
         case self
         when .constructor?      then "#{name}_CONSTRUCT"
         when .copy_constructor? then "#{name}_COPY"
+        when .member_getter?    then "#{name}_GETTER"
+        when .member_setter?    then "#{name}_SETTER"
         when .operator?         then operator_name
         when .static_method?    then "#{name}_STATIC"
         when .destructor?       then "#{name}_DESTROY"

--- a/src/bindgen/parser/type.cr
+++ b/src/bindgen/parser/type.cr
@@ -195,6 +195,26 @@ kind: Kind::Function,
         )
       end
 
+      # If the type is a pointer and not a reference, returns a copy of this
+      # type that is nilable, otherwise returns `nil`.
+      def make_pointer_nilable : Type?
+        if @pointer > 0 && !@isReference && !@isMove
+          Type.new(
+            kind: @kind,
+            isConst: @isConst,
+            isReference: false,
+            isMove: false,
+            isBuiltin: @isBuiltin,
+            isVoid: @isVoid,
+            pointer: @pointer,
+            baseName: @baseName,
+            fullName: @fullName,
+            template: @template,
+            nilable: true,
+          )
+        end
+      end
+
       def_equals_and_hash @baseName, @fullName, @isConst, @isReference, @isMove, @isBuiltin, @isVoid, @pointer, @kind, @nilable
 
       def initialize(@baseName, @fullName, @isConst, @isReference, @pointer, @isMove = false, @isBuiltin = false, @isVoid = false, @kind = Kind::Class, @template = nil, @nilable = false)

--- a/src/bindgen/processor.cr
+++ b/src/bindgen/processor.cr
@@ -24,6 +24,7 @@ module Bindgen
       "copy_structs",
       "macros",
       "functions",
+      "instance_properties",
       "filter_methods",
       # "auto_container_instantiation", # Not stable yet
       "extern_c",

--- a/src/bindgen/processor/instance_properties.cr
+++ b/src/bindgen/processor/instance_properties.cr
@@ -1,0 +1,111 @@
+module Bindgen
+  module Processor
+    # Processor to add getter and setter methods for instance variables.
+    class InstanceProperties < Base
+      def initialize(*args)
+        super
+      end
+
+      def visit_class(klass : Graph::Class)
+        # Skip `Impl` classes.  Also skip classes whose structures are copied
+        # into `Binding`, as all fields are directly accessible anyway.
+        return if klass.wrapped_class || @db[klass.name]?.try(&.copy_structure)
+
+        klass.origin.each_field do |field|
+          # Ignore private fields.  Also ignore all reference fields for now.
+          next if field.private? || field.reference? || field.move?
+
+          add_getter(klass, field)
+          add_setter(klass, field) unless field.const?
+        end
+
+        super
+      end
+
+      # Builds a C++ wrapper method for an instance variable getter.  The `lib`
+      # binding and the Crystal wrapper method are generated later.
+      private def add_getter(klass, field)
+        # C++'s `protected` is closer to Crystal's `private` than to `protected`
+        access = field.protected? ?
+          Parser::AccessSpecifier::Private : Parser::AccessSpecifier::Public
+
+        method_origin = Parser::Method.new(
+          name: field.name,
+          className: klass.origin.name,
+          returnType: field.as(Parser::Type),
+          arguments: [] of Parser::Argument,
+          type: Parser::Method::Type::MemberGetter,
+          access: access,
+          isConst: true,
+        )
+
+        method = Graph::Method.new(
+          name: method_origin.name,
+          origin: method_origin,
+          parent: klass,
+        )
+
+        body = GetterBody.new
+        target = CallBuilder::CppCall.new(@db).build(method_origin, body: body)
+        call = CallBuilder::CppWrapper.new(@db).build(method_origin, target)
+        method.calls[Graph::Platform::Cpp] = call
+      end
+
+      # Code body for reading from a C++ instance variable.
+      private class GetterBody < Call::Body
+        def to_code(call : Call, _platform : Graph::Platform) : String
+          code = call.name
+
+          if templ = call.result.conversion
+            code = Util.template(templ, code)
+          end
+
+          code
+        end
+      end
+
+      # Builds a C++ wrapper method for an instance variable setter.  The `lib`
+      # binding and the Crystal wrapper method are generated later.
+      private def add_setter(klass, field)
+        # C++'s `protected` is closer to Crystal's `private` than to `protected`
+        access = field.protected? ?
+          Parser::AccessSpecifier::Private : Parser::AccessSpecifier::Public
+
+        arg = Parser::Argument.new(field.name, field.as(Parser::Type))
+
+        method_origin = Parser::Method.new(
+          name: field.name,
+          className: klass.origin.name,
+          returnType: Parser::Type::VOID,
+          arguments: [arg],
+          type: Parser::Method::Type::MemberSetter,
+          access: access,
+        )
+
+        method = Graph::Method.new(
+          name: method_origin.name,
+          origin: method_origin,
+          parent: klass,
+        )
+
+        body = SetterBody.new
+        target = CallBuilder::CppCall.new(@db).build(method_origin, body: body)
+        call = CallBuilder::CppWrapper.new(@db).build(method_origin, target)
+        method.calls[Graph::Platform::Cpp] = call
+      end
+
+      # Code body for writing to a C++ instance variable.
+      private class SetterBody < Call::Body
+        def to_code(call : Call, _platform : Graph::Platform) : String
+          code = call.arguments.first.call
+
+          if templ = call.result.conversion
+            code = Util.template(templ, code)
+          end
+
+          "#{call.name} = #{code}"
+        end
+      end
+    end
+  end
+end

--- a/src/bindgen/processor/instance_properties.cr
+++ b/src/bindgen/processor/instance_properties.cr
@@ -27,6 +27,7 @@ module Bindgen
           access = field.protected? ?
             Parser::AccessSpecifier::Private : Parser::AccessSpecifier::Public
           method_name = config.rename ? field.name.gsub(pattern, config.rename) : field.name
+          method_name = method_name.underscore
           field_type = config.nilable ? (field.make_pointer_nilable || field) : field
 
           add_getter(klass, access, field_type, field.name, method_name)

--- a/src/bindgen/util.cr
+++ b/src/bindgen/util.cr
@@ -3,6 +3,9 @@ module Bindgen
     # Matches back-references in strings.
     BACKREFERENCE_RX = /\\(\d)/
 
+    # Matches absolutely nothing, not even the empty string.
+    FAIL_RX = /(?!)/
+
     # Mimics Rubys `Enumerable#uniq_by`.  Takes a *list*, and makes all values
     # in it unique by yielding all pairs, keeping only those items where the
     # block returned a falsy value.


### PR DESCRIPTION
Resolves #71. The integration test generates the following extra methods in the Crystal wrappers:

```crystal
module Test
  class Point
    def x() : Int32 end
    def x=(x : Int32) : Void end
    def y() : Int32 end
    def y=(y : Int32) : Void end
  end

  class Props
    def x_pub() : Int32 end
    def x_pub=(x_pub : Int32) : Void end
    def y_pub() : Int32 end
    def position_ptr() : Point end
    def position_ptr=(position_ptr : Point) : Void end
    def position_val() : Point end
    def position_val=(position_val : Point) : Void end
    private def x_prot() : Int32 end
    private def x_prot=(x_prot : Int32) : Void end
    private def y_prot() : Int32 end
  end
end
```

Some implementation notes:

* It skips over types that have `copy_structure: true`, because these structs are readily available and don't need further property methods.
* Protected C++ fields are mapped to private Crystal methods, for essentially the same reason as `#superclass`.
* Static data members are not supported (neither does the Clang parser, it seems).
* It has not been tested on qt5.cr yet, although the impact should be minimal since Qt encapsulates almost every class.
* There isn't an opt-out mechanism yet.
* Incidentally this provides a new way to directly wrap C/C++ plain structs into Crystal `Class`es. `Point` is already an example but we could go one step further and synthesize its constructor in a processor too.
* ~~The processor assumes that every pointer member owns the pointed-to memory, which is not always true.~~ (My mistake; pointers don't do this actually.) The corresponding setters also don't support `nil`.

The YAML config will probably be something like this:

```yaml
types:
  Props:
    instance_variables:
      # renames the property methods; regex expressions are supported
      "^(.)_pub$": { name: "\\1_public" }

      # this will hide all the property methods
      ".*": { ignore: true }

      # do not allocate new instances when accessing and modifying through a pointer member
      # (e.g. intrusive linked lists; I haven't figured out the proper semantics for this)
      # "position_ptr": { weak: true }

      # allow null pointers
      "position_ptr": { nilable: true }
```
