### PR TITLE
Preliminary support for C arrays

### DIFF
--- a/clang/include/structures.hpp
+++ b/clang/include/structures.hpp
@@ -15,6 +15,7 @@ struct Type {
 	bool isReference = false; // If this is a reference
 	bool isBuiltin = false; // If this is a C++ built-in type.
 	bool isVoid = false; // If the derefenced type is C++ `void`.
+	std::vector<uint64_t> extents; // C array extents, e.g. `int[][5][3]` => `{0, 5, 3}`
 	std::string baseName; // Base type. E.g., `const Foo *&` => `Foo`
 	std::string fullName; // Full name, for C++. E.g. `const Foo *&`
 
@@ -25,7 +26,7 @@ JsonStream &operator<<(JsonStream &s, const Type &value);
 
 struct Template {
 	std::string fullName; // The template class, e.g. `std::vector<_Tp, _Alloc>` in `std::vector<std::string>`
-  std::string baseName; // The template class-name, e.g. `std::vector`
+	std::string baseName; // The template class-name, e.g. `std::vector`
 	std::vector<Type> arguments; // Arguments, e.g. `std::string`
 };
 
@@ -97,6 +98,8 @@ struct Method {
 		CopyConstructor,
 		// Destructor,
 		MemberMethod,
+		// MemberGetter,
+		// MemberSetter,
 		StaticMethod,
 		Operator, // Overloaded operator
 		Signal, // Qt signal

--- a/clang/src/structures.cpp
+++ b/clang/src/structures.cpp
@@ -10,6 +10,7 @@ static JsonStream &writeTypeJson(JsonStream &s, const Type &value) {
 		<< std::make_pair("isBuiltin", value.isBuiltin) << c
 		<< std::make_pair("isVoid", value.isVoid) << c
 		<< std::make_pair("pointer", value.pointer) << c
+		<< std::make_pair("extents", value.extents) << c
 		<< std::make_pair("baseName", value.baseName) << c
 		<< std::make_pair("fullName", value.fullName) << c
 		<< std::make_pair("template", value.templ);

--- a/spec/bindgen/parser/type_spec.cr
+++ b/spec/bindgen/parser/type_spec.cr
@@ -6,25 +6,32 @@ end
 
 describe Bindgen::Parser::Type do
   describe "#decayed" do
-    it "returns nil for base type" do # Rule 4
+    it "returns nil for base type" do # Rule 5
       parse("int").decayed.should be_nil
     end
 
-    it "decays pointer depth" do # Rule 3
+    it "decays pointer depth" do # Rule 4
       parse("int **").decayed.should eq(parse("int *"))
       parse("int *").decayed.should eq(parse("int"))
     end
 
-    it "decays reference" do # Rule 2
+    it "decays reference" do # Rule 3
       parse("int *&").decayed.should eq(parse("int **"))
       parse("int &").decayed.should eq(parse("int *"))
     end
 
-    it "decays const" do # Rule 1
+    it "decays const" do # Rule 2
       parse("const int *&").decayed.should eq(parse("int *&"))
       parse("const int &").decayed.should eq(parse("int &"))
       parse("const int *").decayed.should eq(parse("int *"))
       parse("const int").decayed.should eq(parse("int"))
+    end
+
+    it "decays arrays" do # Rule 1
+      parse("int [4]").decayed.should eq(parse("int"))
+      parse("int *[4]").decayed.should eq(parse("int *"))
+      parse("int [4][3]").decayed.should eq(parse("int [3]"))
+      parse("int *[4][3]").decayed.should eq(parse("int *[3]"))
     end
   end
 
@@ -99,6 +106,82 @@ describe Bindgen::Parser::Type do
       type.pointer.should eq(2)
       type.base_name.should eq("int")
       type.full_name.should eq("const int **")
+    end
+
+    it "recognizes 'int [4]'" do
+      type = parse("int [4]")
+      type.const?.should be_false
+      type.reference?.should be_false
+      type.extents.should eq([4] of UInt64)
+      type.pointer.should eq(1)
+      type.base_name.should eq("int")
+      type.full_name.should eq("int [4]")
+    end
+
+    it "recognizes 'int[4]'" do
+      type = parse("int[4]")
+      type.const?.should be_false
+      type.reference?.should be_false
+      type.extents.should eq([4] of UInt64)
+      type.pointer.should eq(1)
+      type.base_name.should eq("int")
+      type.full_name.should eq("int[4]")
+    end
+
+    it "recognizes 'int []'" do
+      type = parse("int []")
+      type.const?.should be_false
+      type.reference?.should be_false
+      type.extents.should eq([0] of UInt64)
+      type.pointer.should eq(1)
+      type.base_name.should eq("int")
+      type.full_name.should eq("int []")
+    end
+
+    it "recognizes 'int [4][3][2]'" do
+      type = parse("int [4][3][2]")
+      type.const?.should be_false
+      type.reference?.should be_false
+      type.extents.should eq([4, 3, 2] of UInt64)
+      type.pointer.should eq(3)
+      type.base_name.should eq("int")
+      type.full_name.should eq("int [4][3][2]")
+    end
+
+    it "recognizes 'int [][3][2]'" do
+      type = parse("int [][3][2]")
+      type.const?.should be_false
+      type.reference?.should be_false
+      type.extents.should eq([0, 3, 2] of UInt64)
+      type.pointer.should eq(3)
+      type.base_name.should eq("int")
+      type.full_name.should eq("int [][3][2]")
+    end
+
+    it "recognizes 'const int [4]'" do
+      type = parse("const int [4]")
+      type.const?.should be_true
+      type.reference?.should be_false
+      type.extents.should eq([4] of UInt64)
+      type.pointer.should eq(1)
+      type.base_name.should eq("int")
+      type.full_name.should eq("const int [4]")
+    end
+
+    it "recognizes 'int * [4]'" do
+      type = parse("int * [4]")
+      type.const?.should be_false
+      type.reference?.should be_false
+      type.extents.should eq([4] of UInt64)
+      type.pointer.should eq(2)
+      type.base_name.should eq("int")
+      type.full_name.should eq("int * [4]")
+    end
+
+    pending "recognizes 'int (&) [4]'" do
+    end
+
+    pending "recognizes 'int [4] *'" do
     end
 
     it "supports pointer depth offset" do

--- a/spec/clang/functions_spec.cr
+++ b/spec/clang/functions_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
-describe "clang tool macros feature" do
-  it "exports the macros" do
+describe "clang tool functions feature" do
+  it "exports the C functions" do
     clang_tool(
       %[
         void simple();

--- a/spec/integration/basic.cpp
+++ b/spec/integration/basic.cpp
@@ -55,3 +55,13 @@ public:
 struct ImplicitConstructor {
   int itWorks() { return 1; }
 };
+
+struct PlainStruct {
+  int x;
+  int *xp;
+  int y[4];
+  int *yp[6];
+  int z[8][16];
+  void *vp;
+  void **vpp;
+};

--- a/spec/integration/basic.yml
+++ b/spec/integration/basic.yml
@@ -6,6 +6,7 @@ classes:
   Adder: AdderWrap
   ImplicitConstructor: ImplicitConstructor
   TypeConversion: TypeConversion
+  PlainStruct: PlainStruct
 
 types:
   IgnoreMe: # Ignore by type
@@ -18,3 +19,7 @@ types:
     wrapper_pass_by: Value
     to_crystal: "String.new(%)"
     from_crystal: "%.to_unsafe"
+  PlainStruct:
+    generate_binding: false
+    generate_wrapper: false
+    copy_structure: true

--- a/spec/integration/basic_spec.cr
+++ b/spec/integration/basic_spec.cr
@@ -40,6 +40,21 @@ describe "a basic C++ wrapper" do
         end
       end
 
+      context "copy structure" do
+        it "supports normal members" do
+          Test::Binding::PlainStruct.new.x.should be_a(Int32)
+          Test::Binding::PlainStruct.new.xp.should be_a(Pointer(Int32))
+          Test::Binding::PlainStruct.new.vp.should be_a(Pointer(Void))
+          Test::Binding::PlainStruct.new.vpp.should be_a(Pointer(Pointer(Void)))
+        end
+
+        it "supports array members" do
+          Test::Binding::PlainStruct.new.y.should be_a(StaticArray(Int32, 4))
+          Test::Binding::PlainStruct.new.yp.should be_a(StaticArray(Pointer(Int32), 6))
+          Test::Binding::PlainStruct.new.z.should be_a(StaticArray(StaticArray(Int32, 16), 8))
+        end
+      end
+
       context "type decay matching" do
         it "supports specialized matching" do
           subject = Test::TypeConversion.new
@@ -51,11 +66,11 @@ describe "a basic C++ wrapper" do
           subject = Test::TypeConversion.new
           subject.next(5u8).should eq(6u8)
         end
-      end
 
-      it "returns a void pointer" do
-        subject = Test::TypeConversion.new
-        subject.void_pointer.address.should eq(0x11223344)
+        it "returns a void pointer" do
+          subject = Test::TypeConversion.new
+          subject.void_pointer.address.should eq(0x11223344)
+        end
       end
     end
   end

--- a/src/bindgen/cpp/typename.cr
+++ b/src/bindgen/cpp/typename.cr
@@ -14,7 +14,8 @@ module Bindgen
           b << base_name
 
           stars = "*" * pointer if pointer > 0
-          subscripts = extents.map {|v| "[#{v unless v.zero?}]"}.join unless extents.empty?
+          subscripts = extents.map {|v| "[#{v unless v.zero?}]"}.join unless
+            extents.nil? || extents.empty?
           ref = "&" if is_reference
 
           b << ' ' if stars || ref || subscripts

--- a/src/bindgen/cpp/typename.cr
+++ b/src/bindgen/cpp/typename.cr
@@ -4,22 +4,21 @@ module Bindgen
     struct Typename
       # Formats the type in *result* in C++ style.
       def full(result : Call::Expression) : String
-        full(result.type_name, result.type.const?, result.pointer, result.reference)
+        full(result.type_name, result.type.const?, result.pointer, result.reference, result.type.extents)
       end
 
       # ditto
-      def full(base_name : String, const, pointer, is_reference) : String
-        stars = "*" * pointer
-        ref = "&" if is_reference
-
+      def full(base_name : String, const, pointer, is_reference, extents) : String
         String.build do |b|
           b << "const " if const
           b << base_name
 
-          if pointer > 0 || is_reference
-            b << ' ' << ("*" * pointer)
-            b << '&' if is_reference
-          end
+          stars = "*" * pointer if pointer > 0
+          subscripts = extents.map {|v| "[#{v unless v.zero?}]"}.join unless extents.empty?
+          ref = "&" if is_reference
+
+          b << ' ' if stars || ref || subscripts
+          b << stars << subscripts << ref
         end
       end
 

--- a/src/bindgen/parser/argument.cr
+++ b/src/bindgen/parser/argument.cr
@@ -16,6 +16,10 @@ module Bindgen
         isBuiltin: Bool,
         isVoid: Bool,
         pointer: Int32,
+        extents: {
+          type:    Array(UInt64),
+          default: Array(UInt64).new,
+        },
         baseName: String,
         fullName: String,
         nilable: {
@@ -42,7 +46,8 @@ module Bindgen
       def initialize(
         @name, @baseName, @fullName, @isConst, @isReference, @isMove, @isBuiltin,
         @isVoid, @pointer, @kind = Type::Kind::Class, @hasDefault = false,
-        @value = nil, @nilable = false, @isVariadic = false
+        @value = nil, @nilable = false, @isVariadic = false,
+        @extents = Array(UInt64).new
       )
       end
 
@@ -56,12 +61,15 @@ module Bindgen
         @isVoid = type.isVoid
         @isVariadic = false
         @pointer = type.pointer
+        @extents = type.extents
         @kind = type.kind
         @template = type.template
         @nilable = type.nilable
       end
 
-      def_equals_and_hash @baseName, @fullName, @isConst, @isReference, @isMove, @isBuiltin, @isVoid, @pointer, @hasDefault, @name, @value, @nilable
+      def_equals_and_hash @baseName, @fullName, @isConst, @isReference, @isMove,
+        @isBuiltin, @isVoid, @pointer, @hasDefault, @name, @value, @nilable,
+        @extents
 
       # Does this argument have a default value?
       def has_default?
@@ -100,6 +108,7 @@ module Bindgen
           isBuiltin: @isBuiltin,
           isVoid: @isVoid,
           pointer: @pointer,
+          extents: extents,
           kind: @kind,
           hasDefault: false,
           value: nil,
@@ -121,6 +130,7 @@ module Bindgen
           isBuiltin: @isBuiltin,
           isVoid: @isVoid,
           pointer: @pointer,
+          extents: extents,
           kind: @kind,
           hasDefault: @hasDefault || other.has_default?,
           value: @value || other.value,
@@ -130,7 +140,7 @@ module Bindgen
 
       # Checks if the type-part of this equals the type-part of *other*.
       def type_equals?(other : Type)
-        {% for i in %i[baseName fullName isConst isReference isMove isBuiltin isVoid pointer template] %}
+        {% for i in %i[baseName fullName isConst isReference isMove isBuiltin isVoid pointer extents template] %}
           return false if @{{ i.id }} != other.{{ i.id }}
         {% end %}
 

--- a/src/bindgen/parser/field.cr
+++ b/src/bindgen/parser/field.cr
@@ -14,6 +14,10 @@ module Bindgen
         isBuiltin: Bool,
         isVoid: Bool,
         pointer: Int32,
+        extents: {
+          type:    Array(UInt64),
+          default: Array(UInt64).new,
+        },
         baseName: String,
         fullName: String,
         nilable: {

--- a/src/bindgen/parser/method.cr
+++ b/src/bindgen/parser/method.cr
@@ -384,6 +384,11 @@ module Bindgen
           return true if list.includes?(@name)
         end
 
+        # TODO: Support methods that take or return C arrays (which become
+        # `Slice` in Crystal).
+        return true if @returnType.c_array?
+        return true if @arguments.any?(&.c_array?)
+
         # Check that all arguments, which pass in explicit by-value, either take
         # the value directly, or a const-reference to it.
         pass_by_value_violation = @arguments.any? do |arg|

--- a/src/bindgen/parser/type.cr
+++ b/src/bindgen/parser/type.cr
@@ -14,8 +14,10 @@ module Bindgen
         Function
       end
 
-      # ATTENTION: Changes here have to be kept in sync with `Parser::Argument`s mapping!!
-      # Also make sure to update other methods in here and in `Argument` as required!
+      # ATTENTION: Changes here have to be kept in sync with `Parser::Argument`
+      # and `Parser::Field`'s mapping!!
+      # Also make sure to update other methods in here and in those two classes
+      # as required!
       JSON.mapping(
         kind: {
           type:    Kind,
@@ -27,6 +29,10 @@ module Bindgen
         isBuiltin: Bool,
         isVoid: Bool,
         pointer: Int32,
+        extents: {
+          type:    Array(UInt64),
+          default: Array(UInt64).new,
+        },
         baseName: String,
         fullName: String,
         nilable: {
@@ -48,6 +54,7 @@ module Bindgen
         isBuiltin: true,
         isVoid: true,
         pointer: 0,
+        extents: Array(UInt64).new,
         baseName: "void",
         fullName: "void",
         template: nil,
@@ -63,6 +70,7 @@ module Bindgen
         isBuiltin: true,
         isVoid: false,
         pointer: 0,
+        extents: Array(UInt64).new,
         baseName: "",
         fullName: "",
         template: nil,
@@ -78,6 +86,7 @@ module Bindgen
           isBuiltin: true,
           isVoid: (cpp_name == "void"),
           pointer: pointer,
+          extents: Array(UInt64).new,
           baseName: cpp_name,
           fullName: cpp_name,
           template: nil,
@@ -104,6 +113,14 @@ module Bindgen
           name = name[0..-2] # Remove ampersand
         end
 
+        # Is it a C array?
+        extents = [] of UInt64
+        while subscript = name.match(/\s*\[\s*(\d*)\s*\]\s*$/)
+          extents.unshift subscript[1].to_u64 { 0_u64 }
+          pointer_depth += 1
+          name = subscript.pre_match
+        end
+
         # Is it a pointer?
         while name.ends_with?('*')
           pointer_depth += 1
@@ -111,12 +128,13 @@ module Bindgen
         end
 
         new( # Build the `Type`
-isConst: const,
+          isConst: const,
           isMove: false,
           isReference: reference,
           isBuiltin: false, # Oh well
           isVoid: (name == "void"),
           pointer: pointer_depth,
+          extents: extents,
           baseName: name.strip,
           fullName: type_name,
           template: nil,
@@ -139,13 +157,14 @@ isConst: const,
         )
 
         new( # Build the `Type`
-kind: Kind::Function,
+          kind: Kind::Function,
           isConst: false,
           isMove: false,
           isReference: false,
           isBuiltin: false,
           isVoid: false,
           pointer: 0,
+          extents: Array(UInt64).new,
           baseName: base,
           fullName: base,
           template: template,
@@ -157,27 +176,32 @@ kind: Kind::Function,
       # removed from this type.  Each rule is tried in the following order.
       # The first winning rule returns a new type.
       #
-      # 1. If `#const?`, remove const (`const int &` -> `int &`)
-      # 2. If `#reference?`, pointer-ize (`int &` -> `int *`)
-      # 3. If `#pointer > 0`, remove one (`int *` -> `int`)
-      # 4. Else, it's the base-type already.  Return `nil`.
+      # 1. If `#c_array?`, remove outermost extent (`int [4][3]` -> `int [3]`)
+      # 2. If `#const?`, remove const (`const int &` -> `int &`)
+      # 3. If `#reference?`, pointer-ize (`int &` -> `int *`)
+      # 4. If `#pointer > 0`, remove one (`int *` -> `int`)
+      # 5. Else, it's the base-type already.  Return `nil`.
       def decayed : Type?
         is_const = @isConst
         is_ref = @isReference
         ptr = @pointer
+        extents = @extents
 
-        if is_const # 1.
-          is_const = false
-        elsif is_ref # 2.
-          is_ref = false
-        elsif ptr > 0 # 3.
+        if extents.size > 0 # 1,
+          extents = extents[1..]
           ptr -= 1
-        else # 4.
+        elsif is_const # 2.
+          is_const = false
+        elsif is_ref # 3.
+          is_ref = false
+        elsif ptr > 0 # 4.
+          ptr -= 1
+        else # 5.
           return nil
         end
 
         typer = Cpp::Typename.new
-        type_ptr = ptr
+        type_ptr = ptr - extents.size
         type_ptr -= 1 if is_ref
 
         Type.new(
@@ -188,8 +212,9 @@ kind: Kind::Function,
           isBuiltin: @isBuiltin,
           isVoid: @isVoid,
           pointer: ptr,
+          extents: extents,
           baseName: @baseName,
-          fullName: typer.full(@baseName, is_const, type_ptr, is_ref),
+          fullName: typer.full(@baseName, is_const, type_ptr, is_ref, extents),
           template: @template,
           nilable: @nilable,
         )
@@ -207,6 +232,7 @@ kind: Kind::Function,
             isBuiltin: @isBuiltin,
             isVoid: @isVoid,
             pointer: @pointer,
+            extents: extents,
             baseName: @baseName,
             fullName: @fullName,
             template: @template,
@@ -215,9 +241,14 @@ kind: Kind::Function,
         end
       end
 
-      def_equals_and_hash @baseName, @fullName, @isConst, @isReference, @isMove, @isBuiltin, @isVoid, @pointer, @kind, @nilable
+      def_equals_and_hash @baseName, @fullName, @isConst, @isReference, @isMove,
+        @isBuiltin, @isVoid, @pointer, @kind, @nilable, @extents
 
-      def initialize(@baseName, @fullName, @isConst, @isReference, @pointer, @isMove = false, @isBuiltin = false, @isVoid = false, @kind = Kind::Class, @template = nil, @nilable = false)
+      def initialize(
+        @baseName, @fullName, @isConst, @isReference, @pointer, @isMove = false,
+        @isBuiltin = false, @isVoid = false, @kind = Kind::Class,
+        @template = nil, @nilable = false, @extents = Array(UInt64).new
+      )
       end
 
       # Is this type nilable?  For compatibility with `Argument`.
@@ -225,8 +256,8 @@ kind: Kind::Function,
 
       # Checks if this type equals the *other* type, except for nil-ability.
       def equals_except_nil?(other : Type)
-        {% for i in %i[baseName fullName isConst isReference isMove isBuiltin isVoid pointer kind] %}
-        return false if @{{ i.id }} != other.{{ i.id }}
+        {% for i in %i[baseName fullName isConst isReference isMove isBuiltin isVoid pointer kind extents] %}
+          return false if @{{ i.id }} != other.{{ i.id }}
         {% end %}
 
         true
@@ -261,6 +292,21 @@ kind: Kind::Function,
       # Returns `true` if this type is `void`, and nothing else.
       def pure_void?
         @isVoid && @pointer == 0
+      end
+
+      # The array extents of this type.
+      def extents
+        @extents.dup
+      end
+
+      # Is this type a C array?
+      def c_array?
+        @extents.size > 0
+      end
+
+      # Is this type a C array with known size?
+      def c_complete_array?
+        c_array? && @extents.none?(&.zero?)
       end
 
       # Unqualified base name for easier mapping to Crystal.

--- a/src/bindgen/processor/copy_structs.cr
+++ b/src/bindgen/processor/copy_structs.cr
@@ -39,7 +39,7 @@ module Bindgen
       private def copy_structure(klass, root)
         typename = Crystal::Typename.new(@db)
         Graph::Struct.new( # Add the struct into the graph
-name: typename.binding(klass.as_type).first.camelcase,
+          name: typename.binding(klass.as_type).first.camelcase,
           fields: fields_to_graph(klass.fields),
           parent: root,
         )

--- a/src/bindgen/processor/sanity_check.cr
+++ b/src/bindgen/processor/sanity_check.cr
@@ -143,6 +143,19 @@ module Bindgen
         super
       end
 
+      # Check for invalid types in structures
+      def visit_struct(structure)
+        structure.fields.each do |name, result|
+          if result.reference
+            add_error(structure, "Struct field #{name} is a reference")
+          end
+
+          if result.type.c_array? && !result.type.c_complete_array?
+            add_error(structure, "Struct field #{name} is a C array with unknown bounds")
+          end
+        end
+      end
+
       # Check reachability of all types
       private def visit_method(method)
         call = method.calls[@platform]?

--- a/src/bindgen/processor/virtual_override.cr
+++ b/src/bindgen/processor/virtual_override.cr
@@ -327,7 +327,7 @@ module Bindgen
         # Pass by reference.
         table_type = Parser::Type.new(
           baseName: table_name,
-          fullName: typer.full(table_name, const: false, pointer: 0, is_reference: true),
+          fullName: typer.full(table_name, const: false, pointer: 0, is_reference: true, extents: nil),
           isConst: true,
           isReference: true,
           pointer: 1,


### PR DESCRIPTION
Adds support for C array types, i.e. `int [4][3][2]`. It is not to be confused with `std::array`.

* [x] Allow `StaticArray` members in `lib struct`s generated by `copy_structure: true`. Multi-dimensional C arrays are also supported. VLAs are rejected by SanityCheck, because Crystal doesn't support them either.
* [ ] Allow wrapper methods to take array arguments or return arrays. They are wrapped in `Slice` if the bounds are known, and `Pointer` otherwise.
* [ ] Generate instance getter methods for array members, which should always return a `Slice` (read-only if the array fields are `const`). There will be no corresponding setters.

Optional features:

* The Clang parser's output format cannot distinguish between an array of pointers (`int *x[4]`) and a pointer to an array (`int (*x)[4]`). This patch assumes the former as it is way more common in C code than the latter, although in C++ `int (&x)[4]` would translate to the latter. The two can be differentiated by treating _every_ array / pointer layer as a pseudo-generic type, similar to `Bindgen::Parser::Type#template`. The downside is that each layer creates a new type.
* The parser might need to distinguish between `const` pointers and pointers-to-`const` as well.
* Map C array constants to Crystal `Array`s, provided they only contain other supported constants (`Int | Float | String | Bool`).

This patch also fixes what I believe to be a bug where CopyStructs converts `void **` fields to a plain `void *`.