### PR TITLE
Improve Graph::Path

### DIFF
--- a/spec/bindgen/graph/path_spec.cr
+++ b/spec/bindgen/graph/path_spec.cr
@@ -326,6 +326,7 @@ describe Bindgen::Graph::Path do
 
     it "ignores type arguments of generic types" do
       path("Foo(Stuff)::Bar").should eq(path("Foo::Bar"))
+      path("Proc(Tuple(Foo::Bar,Baz),Quux,Array(T))::T").should eq(path("Proc::T"))
     end
   end
 
@@ -403,20 +404,20 @@ describe Bindgen::Graph::Path do
     end
 
     it "builds a fake-global path if not found" do
-      s = Bindgen::Graph::Namespace.new("J")
+      s = Bindgen::Graph::Namespace.new("S")
       t = Bindgen::Graph::Namespace.new("T", s)
 
       # a and t don't share any ancestor.
-      Bindgen::Graph::Path.local(a, t).should eq(path("J::T"))
+      Bindgen::Graph::Path.local(a, t).should eq(path("S::T"))
     end
   end
 
   describe ".global" do
     it "returns the global path to the node" do
-      s = Bindgen::Graph::Namespace.new("J")
+      s = Bindgen::Graph::Namespace.new("S")
       t = Bindgen::Graph::Namespace.new("T", s)
 
-      Bindgen::Graph::Path.global(t).should eq(path("::J::T"))
+      Bindgen::Graph::Path.global(t).should eq(path("::S::T"))
     end
   end
 

--- a/src/bindgen/graph/builder.cr
+++ b/src/bindgen/graph/builder.cr
@@ -90,11 +90,11 @@ module Bindgen
       # Iterates over the *path*, descending from *root* onwards.  If a part of
       # the path does not exist yet, it'll be created as `Namespace`.
       def get_or_create_path(root : Graph::Container, path : Path) : Graph::Node
-        if path.global?
+        if path.global? || path.self_path?
           return root
         end
 
-        path.nodes.not_nil!.reduce(root) do |ctr, name|
+        path.parts.reduce(root) do |ctr, name|
           unless ctr.is_a?(Graph::Container)
             raise "Path #{path.inspect} is illegal, as #{name.inspect} is not a container"
           end

--- a/src/bindgen/processor/crystal_wrapper.cr
+++ b/src/bindgen/processor/crystal_wrapper.cr
@@ -31,7 +31,7 @@ module Bindgen
 
         if structure = klass.structure
           type = klass.origin.as_type(pointer: 0)
-          type_name = Graph::Path.local(klass, structure).to_s
+          type_name = Graph::Path.local(from: klass, to: structure).to_s
         else
           type = klass.origin.as_type(pointer: 1)
           type_name = typer.qualified(*typer.binding(type))

--- a/src/bindgen/processor/inheritance.cr
+++ b/src/bindgen/processor/inheritance.cr
@@ -28,7 +28,7 @@ module Bindgen
 
         unless wrapped.empty?
           # We inherit the first wrapped base-class in Crystal.
-          klass.base_class = Graph::Path.local(klass, wrapped.first).to_s
+          klass.base_class = Graph::Path.local(from: klass, to: wrapped.first).to_s
 
           # For all other base-classes, we provide `#as_X` methods.
           if wrapped.size > 1

--- a/src/bindgen/processor/sanity_check.cr
+++ b/src/bindgen/processor/sanity_check.cr
@@ -148,13 +148,15 @@ module Bindgen
         call = method.calls[@platform]?
         return if call.nil?
 
+        namespace = method.parent.not_nil!
+
         call.arguments.each_with_index do |arg, idx|
-          unless type_reachable?(arg, method)
+          unless type_reachable?(arg, namespace)
             add_error(method, "Argument #{idx + 1} has unreachable type #{arg.type_name}")
           end
         end
 
-        unless type_reachable?(call.result, method)
+        unless type_reachable?(call.result, namespace)
           add_error(method, "Result type #{call.result.type_name} is unreachable")
         end
 

--- a/src/bindgen/util.cr
+++ b/src/bindgen/util.cr
@@ -6,6 +6,10 @@ module Bindgen
     # Matches absolutely nothing, not even the empty string.
     FAIL_RX = /(?!)/
 
+    # Matches strings with balanced parentheses.
+    # (http://www.pcre.org/original/doc/html/pcrepattern.html#SEC23)
+    BALANCED_PARENS_RX = /\( ( [^()]++ | (?R) )* \)/x
+
     # Mimics Rubys `Enumerable#uniq_by`.  Takes a *list*, and makes all values
     # in it unique by yielding all pairs, keeping only those items where the
     # block returned a falsy value.


### PR DESCRIPTION
This fixes all the issues in #80, makes local lookup more robust, and handles nested generic names.

I also added a `Path#join` method, since there are a few places in the source code where I would like to replace strings with paths. `Path.from` is now based on `#join` as well.