### PR TITLE
Better namespace resolution for namespaced types

### DIFF
--- a/TEMPLATE.yml
+++ b/TEMPLATE.yml
@@ -385,7 +385,8 @@ types:
     # Name of this type in the C++ binding.  Useful when used with converters.
     cpp_type: CppTypeName
 
-    # Name of this type in `lib Binding`.
+    # Name of this type in `lib Binding`.  Namespaces are automatically removed
+    # from this name.
     binding_type: CrystalTypeName
 
     # Inserted into C++ to turn the type into something the `binding_type` will

--- a/TEMPLATE.yml
+++ b/TEMPLATE.yml
@@ -385,8 +385,8 @@ types:
     # Name of this type in the C++ binding.  Useful when used with converters.
     cpp_type: CppTypeName
 
-    # Name of this type in `lib Binding`.  Namespaces are automatically removed
-    # from this name.
+    # Name of this type in `lib Binding`.  Namespaces are automatically turned
+    # into underscores (e.g. `Namespace::Type` -> `Namespace_Type`).
     binding_type: CrystalTypeName
 
     # Inserted into C++ to turn the type into something the `binding_type` will

--- a/clang/src/record_match_handler.cpp
+++ b/clang/src/record_match_handler.cpp
@@ -128,7 +128,7 @@ BaseClass RecordMatchHandler::handleBaseClass(const clang::CXXBaseSpecifier &bas
 	b.isVirtual = base.isVirtual();
 	b.inheritedConstructor = base.getInheritConstructors();
 	b.access = base.getAccessSpecifier();
-	b.name = base.getType()->getAsCXXRecordDecl()->getNameAsString();
+	b.name = base.getType()->getAsCXXRecordDecl()->getQualifiedNameAsString();
 
 	return b;
 }

--- a/spec/integration/inheritance.cpp
+++ b/spec/integration/inheritance.cpp
@@ -75,4 +75,9 @@ struct Derived2 : Module::Super2 { };
 namespace Module {
   struct Super3 { };
   struct Derived3 : Super3 { };
+
+  struct SuperV {
+    virtual ~SuperV() { }
+    virtual void f() { }
+  };
 }

--- a/spec/integration/inheritance.cpp
+++ b/spec/integration/inheritance.cpp
@@ -60,3 +60,19 @@ struct Skip {
     return 7;
   }
 };
+
+
+
+struct Super1 { };
+
+namespace Module {
+  struct Derived1 : Super1 { };
+  struct Super2 { };
+}
+
+struct Derived2 : Module::Super2 { };
+
+namespace Module {
+  struct Super3 { };
+  struct Derived3 : Super3 { };
+}

--- a/spec/integration/inheritance.yml
+++ b/spec/integration/inheritance.yml
@@ -13,3 +13,9 @@ classes:
   Base: Base
   AbstractThing: AbstractThing
   Subclass: Subclass
+  Super1: Super1
+  Module::Derived1: Module::Derived1
+  Module::Super2: Module::Super2
+  Derived2: Derived2
+  Module::Super3: Module::Super3
+  Module::Derived3: Module::Derived3

--- a/spec/integration/inheritance_spec.cr
+++ b/spec/integration/inheritance_spec.cr
@@ -9,6 +9,14 @@ describe "single and multiple inheritance feature" do
         {{ Test::Base.superclass == Reference }}.should be_true
       end
 
+      context "namespaced classes" do
+        it "sets the base-class correctly" do
+          {{ Test::Module::Derived1.superclass == Test::Super1 }}.should be_true
+          {{ Test::Derived2.superclass == Test::Module::Super2 }}.should be_true
+          {{ Test::Module::Derived3.superclass == Test::Module::Super3 }}.should be_true
+        end
+      end
+
       it "sets the abstract class attribute" do
         {{ Test::AbstractThing.abstract? }}.should be_true
         {{ Test::Subclass.abstract? }}.should be_false

--- a/spec/integration/virtual_override.yml
+++ b/spec/integration/virtual_override.yml
@@ -16,6 +16,7 @@ classes:
   Subclass: Subclass
   Implicit: Implicit
   Skip: Skip
+  Module::SuperV: Module::SuperV
 
 types:
   Subclass:

--- a/spec/integration/virtual_override_spec.cr
+++ b/spec/integration/virtual_override_spec.cr
@@ -122,6 +122,12 @@ describe "C++ virtual overriding from Crystal feature" do
           SubOverrideThing.new.has_random_number?.should be_false
         end
       end
+
+      context "namespaced classes" do
+        it "compiles" do
+          Test::Module::SuperV.new.f
+        end
+      end
     end
   end
 end

--- a/src/bindgen/generator/cpp.cr
+++ b/src/bindgen/generator/cpp.cr
@@ -65,8 +65,9 @@ module Bindgen
         puts "#{prototype} {"
         indented do
           if structure.tag?(Graph::Struct::INHERIT_CONSTRUCTORS_TAG)
-            base = structure.base_class
-            puts "using #{base}::#{base};" # C++11
+            base = structure.base_class.not_nil!
+            ctor = Graph::Path.from(base).last_part
+            puts "using #{base}::#{ctor};" # C++11
           end
 
           structure.fields.each do |name, type|

--- a/src/bindgen/parser/base_class.cr
+++ b/src/bindgen/parser/base_class.cr
@@ -5,7 +5,7 @@ module Bindgen
       JSON.mapping(
         isVirtual: Bool,
         inheritedConstructor: Bool,
-        name: String,
+        name: String, # fully qualified!
         access: AccessSpecifier,
       )
 

--- a/src/bindgen/processor/sanity_check.cr
+++ b/src/bindgen/processor/sanity_check.cr
@@ -156,8 +156,10 @@ module Bindgen
           end
         end
 
-        unless type_reachable?(call.result, namespace)
-          add_error(method, "Result type #{call.result.type_name} is unreachable")
+        unless method.origin.any_constructor?
+          unless type_reachable?(call.result, namespace)
+            add_error(method, "Result type #{call.result.type_name} is unreachable")
+          end
         end
 
         if method.origin.variadic? && method.tag?(Graph::Method::EXPLICIT_BIND_TAG).nil?

--- a/src/bindgen/processor/virtual_override.cr
+++ b/src/bindgen/processor/virtual_override.cr
@@ -364,7 +364,7 @@ module Bindgen
 
         rules = @db.get_or_add(cpp_struct.name)
         rules.graph_node = crystal_struct
-        rules.crystal_type = typer.qualified(crystal_struct.name, in_lib: true)
+        rules.crystal_type = crystal_struct.name
         rules.cpp_type = cpp_struct.name
         rules.pass_by = TypeDatabase::PassBy::Reference
         rules.copy_structure = true
@@ -397,12 +397,12 @@ module Bindgen
 
       # Name of the jumptable structure for both C++ and Crystal.
       private def jumptable_name(klass)
-        "BgJumptable_#{klass.mangled_name}"
+        "BgJumptable_#{klass.origin.binding_name}"
       end
 
       # The name of the shadow sub-class in C++.
       private def subclass_name(klass)
-        "BgInherit_#{klass.mangled_name}"
+        "BgInherit_#{klass.origin.binding_name}"
       end
 
       # Body for `CallBuilder::CppCall`, setting the `bgJump` member in C++.

--- a/src/bindgen/type_database.cr
+++ b/src/bindgen/type_database.cr
@@ -205,13 +205,16 @@ module Bindgen
         @ignore
       end
 
-      # Type name to use in the Crystal `lib` block.
+      # Type name to use in the Crystal `lib` block.  Namespace operators (`::`)
+      # are automatically converted into underscores.
       def lib_type : String?
-        if @copy_structure || @builtin || @kind.enum?
+        typename = if @copy_structure || @builtin || @kind.enum?
           @binding_type || @crystal_type || @cpp_type
         else
           @binding_type || @cpp_type
         end
+
+        typename.try(&.gsub("::", "_"))
       end
 
       # Type name to use in the Crystal wrapper.

--- a/src/bindgen/type_database.cr
+++ b/src/bindgen/type_database.cr
@@ -206,7 +206,8 @@ module Bindgen
       end
 
       # Type name to use in the Crystal `lib` block.  Namespace operators (`::`)
-      # are automatically converted into underscores.
+      # are automatically converted into underscores for types defined in
+      # `lib Binding`.
       def lib_type : String?
         typename = if @copy_structure || @builtin || @kind.enum?
           @binding_type || @crystal_type || @cpp_type
@@ -214,7 +215,11 @@ module Bindgen
           @binding_type || @cpp_type
         end
 
-        typename.try(&.gsub("::", "_"))
+        if @builtin || @kind.enum?
+          typename
+        else
+          typename.try(&.gsub("::", "_"))
+        end
       end
 
       # Type name to use in the Crystal wrapper.


### PR DESCRIPTION
Fixes #67. More specifically,

* The Clang parser now reports inheritance relations using fully qualified names. This allows Bindgen to pick up inherited classes in namespaces.
* Binding type names are guaranteed not to include `::`, by replacing them with underscores.
* C++ `BgInherit` structs now inherit constructors of namespaced types properly.
* The names of `BgJumptable` and `BgInherit` structs now include any enclosing namespaces of the C++ types (because these structs are all emitted to the top-level C++ namespace).

A consequence of these fixes is that namespaced types can be mapped directly:

```yaml
classes:
  Module::Super: Module::Super

types:
  # no longer required, Bindgen always does this now
  # Module::Super: { binding_type: Module_Super }
```

I have also confirmed that this doesn't break qt5.cr (it merely removes a bunch of redundant `Binding::`s under `lib Binding`).