### PR TITLE
Document type for the Clang parser

### DIFF
--- a/clang/include/bindgen_ast_consumer.hpp
+++ b/clang/include/bindgen_ast_consumer.hpp
@@ -7,7 +7,7 @@ class FunctionMatchHandler;
 
 class BindgenASTConsumer : public clang::ASTConsumer {
 public:
-	BindgenASTConsumer(std::vector<Macro> &macros, clang::CompilerInstance &compiler);
+	BindgenASTConsumer(Document &doc, clang::CompilerInstance &compiler);
 
 	~BindgenASTConsumer() override;
 
@@ -17,14 +17,12 @@ private:
 
 	void evaluateMacros(clang::ASTContext &ctx);
 	void serializeAndOutput();
-	void serializeEnumerations(JsonStream &stream);
-	void serializeClasses(JsonStream &stream);
 
 	clang::CompilerInstance &m_compiler;
 	std::vector<RecordMatchHandler *> m_classHandlers;
 	std::vector<EnumMatchHandler *> m_enumHandlers;
 	FunctionMatchHandler *m_functionHandler;
-	std::vector<Macro> &m_macros;
+	Document &m_document;
 	clang::ast_matchers::MatchFinder::MatchFinderOptions m_matchFinderOpts;
 	clang::ast_matchers::MatchFinder m_matchFinder;
 };

--- a/clang/include/bindgen_ast_consumer.hpp
+++ b/clang/include/bindgen_ast_consumer.hpp
@@ -19,9 +19,9 @@ private:
 	void serializeAndOutput();
 
 	clang::CompilerInstance &m_compiler;
-	std::vector<RecordMatchHandler *> m_classHandlers;
-	std::vector<EnumMatchHandler *> m_enumHandlers;
-	FunctionMatchHandler *m_functionHandler;
+	std::vector<std::unique_ptr<RecordMatchHandler>> m_classHandlers;
+	std::vector<std::unique_ptr<EnumMatchHandler>> m_enumHandlers;
+	std::unique_ptr<FunctionMatchHandler> m_functionHandler;
 	Document &m_document;
 	clang::ast_matchers::MatchFinder::MatchFinderOptions m_matchFinderOpts;
 	clang::ast_matchers::MatchFinder m_matchFinder;

--- a/clang/include/bindgen_frontend_action.hpp
+++ b/clang/include/bindgen_frontend_action.hpp
@@ -14,7 +14,7 @@ public:
 	std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef file) override;
 
 private:
-	std::vector<Macro> m_macros;
+	Document m_document;
 };
 
 #endif // BINDGEN_FRONTEND_ACTION_HPPd

--- a/clang/include/enum_match_handler.hpp
+++ b/clang/include/enum_match_handler.hpp
@@ -3,9 +3,7 @@
 
 class EnumMatchHandler : public clang::ast_matchers::MatchFinder::MatchCallback {
 public:
-	EnumMatchHandler(const std::string &name);
-
-	Enum enumeration() const;
+	EnumMatchHandler(Document &doc, const std::string &name);
 
 	virtual void run(const clang::ast_matchers::MatchFinder::MatchResult &Result) override;
 
@@ -19,6 +17,7 @@ public:
 	void handleQFlagsType(const clang::ClassTemplateSpecializationDecl *tmpl);
 
 private:
+	Document &m_document;
 	Enum m_enum;
 };
 

--- a/clang/include/function_match_handler.hpp
+++ b/clang/include/function_match_handler.hpp
@@ -11,19 +11,16 @@ namespace clang {
 
 class FunctionMatchHandler : public clang::ast_matchers::MatchFinder::MatchCallback {
 public:
-	FunctionMatchHandler();
+	FunctionMatchHandler(Document &doc);
 	static bool isActive();
-
-	const std::vector<Method> &functions() const
-	{ return this->m_functions; };
 
 	virtual void run(const clang::ast_matchers::MatchFinder::MatchResult &Result) override;
 	bool isFunctionInteresting(const std::string &name) const;
 	void runOnFunction(const clang::FunctionDecl *func);
 
 private:
+	Document &m_document;
 	Regex m_regex;
-	std::vector<Method> m_functions;
 };
 
 #endif // FUNCTION_MATCH_HANDLER_HPP

--- a/clang/include/helper.hpp
+++ b/clang/include/helper.hpp
@@ -6,16 +6,18 @@
  */
 template< typename T >
 struct CopyPtr {
-	T *ptr;
+	T *ptr = nullptr;
 
-	CopyPtr() : ptr(nullptr) { }
+	CopyPtr() = default;
 	CopyPtr(T *ptr) : ptr(ptr) { }
 	CopyPtr(const T &t) : ptr(new T(t)) { }
 	CopyPtr(const CopyPtr<T> &other) {
-		this->ptr = nullptr;
 		if (other.ptr) {
 			this->ptr = new T(*other.ptr);
 		}
+	}
+	CopyPtr(CopyPtr<T> &&other) : ptr(other.ptr) {
+		other.ptr = nullptr;
 	}
 
 	const T *operator=(const T *other) {
@@ -38,6 +40,12 @@ struct CopyPtr {
 
 	operator bool() const {
 		return this->ptr != nullptr;
+	}
+
+	CopyPtr<T> &operator=(const CopyPtr<T> &other) {
+		delete this->ptr;
+		this->ptr = new T(*other.ptr);
+		return *this;
 	}
 
 	CopyPtr<T> &operator=(CopyPtr<T> &&other) {

--- a/clang/include/helper.hpp
+++ b/clang/include/helper.hpp
@@ -1,6 +1,8 @@
 #ifndef HELPER_HPP
 #define HELPER_HPP
 
+#include <memory>
+
 /* Pointer guard, which copies the instance on each copy.
  * Useful to mark optional data.
  */
@@ -65,5 +67,12 @@ struct CopyPtr {
 	T &operator*() { return *this->ptr; }
 	const T &operator*() const { return *this->ptr; }
 };
+
+// compatibility for C++11
+template< typename T, typename... Args >
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
 
 #endif // HELPER_HPP

--- a/clang/include/json_stream.hpp
+++ b/clang/include/json_stream.hpp
@@ -4,6 +4,7 @@
 #include "helper.hpp"
 #include <ostream>
 #include <vector>
+#include <map>
 
 /* Simple stream writer for JSON data. */
 class JsonStream {
@@ -47,6 +48,21 @@ public:
 		}
 
 		*this << ArrayEnd;
+		return *this;
+	}
+
+	template< typename K, typename V >
+	JsonStream &operator<<(const std::map<K, V> &hash) {
+		bool first = true;
+		*this << ObjectBegin;
+
+		for (const auto &kv : hash) {
+			if (!first) *this << Comma;
+			*this << kv;
+			first = false;
+		}
+
+		*this << ObjectEnd;
 		return *this;
 	}
 

--- a/clang/include/preprocessor_handler.hpp
+++ b/clang/include/preprocessor_handler.hpp
@@ -5,7 +5,7 @@
 
 class PreprocessorHandler : public clang::PPCallbacks {
 public:
-	PreprocessorHandler(std::vector<Macro> &macros, clang::Preprocessor &preprocessor);
+	PreprocessorHandler(Document &doc, clang::Preprocessor &preprocessor);
 
 	void MacroDefined(const clang::Token &token, const clang::MacroDirective *md) override;
 
@@ -15,8 +15,8 @@ private:
 	bool initializeMacro(Macro &m, const clang::Token &token, const clang::MacroDirective *md);
 
 	clang::Preprocessor &m_preprocessor;
-	std::vector<Macro> &m_macros;
-  Regex m_regex;
+	Document &m_document;
+	Regex m_regex;
 };
 
 #endif // PREPROCESSOR_HANDLER_HPP

--- a/clang/include/record_match_handler.hpp
+++ b/clang/include/record_match_handler.hpp
@@ -3,9 +3,7 @@
 
 class RecordMatchHandler : public clang::ast_matchers::MatchFinder::MatchCallback {
 public:
-	RecordMatchHandler(const std::string &name);
-
-	Class klass() const;
+	RecordMatchHandler(Document &doc, const std::string &name);
 
 	virtual void run(const clang::ast_matchers::MatchFinder::MatchResult &Result) override;
 
@@ -20,7 +18,9 @@ public:
 	std::string getSourceFromRange(clang::SourceRange range, clang::SourceManager &sourceMgr);
 
 	BaseClass handleBaseClass(const clang::CXXBaseSpecifier &base);
+
 private:
+	Document &m_document;
 	Class m_class;
 };
 

--- a/clang/include/structures.hpp
+++ b/clang/include/structures.hpp
@@ -174,4 +174,13 @@ struct Macro {
 
 JsonStream &operator<<(JsonStream &s, const Macro &value);
 
+struct Document {
+	std::map<std::string, Enum> enums;
+	std::map<std::string, Class> classes;
+	std::vector<Method> functions;
+	std::vector<Macro> macros;
+};
+
+JsonStream &operator<<(JsonStream &s, const Document &value);
+
 #endif // STRUCTURES_HPP

--- a/clang/src/bindgen_frontend_action.cpp
+++ b/clang/src/bindgen_frontend_action.cpp
@@ -25,18 +25,10 @@ bool BindgenFrontendAction::BeginSourceFileAction(clang::CompilerInstance &ci)
 #endif
 {
 	clang::Preprocessor &preprocessor = ci.getPreprocessor();
-#if __clang_major__ >= 10
-	preprocessor.addPPCallbacks(std::make_unique<PreprocessorHandler>(this->m_document, preprocessor));
-#else
-	preprocessor.addPPCallbacks(llvm::make_unique<PreprocessorHandler>(this->m_document, preprocessor));
-#endif
+	preprocessor.addPPCallbacks(make_unique<PreprocessorHandler>(this->m_document, preprocessor));
 	return true;
 }
 
 std::unique_ptr<clang::ASTConsumer> BindgenFrontendAction::CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef file) {
-#if __clang_major__ >= 10
-	return std::make_unique<BindgenASTConsumer>(this->m_document, ci);
-#else
-	return llvm::make_unique<BindgenASTConsumer>(this->m_document, ci);
-#endif
+	return make_unique<BindgenASTConsumer>(this->m_document, ci);
 }

--- a/clang/src/bindgen_frontend_action.cpp
+++ b/clang/src/bindgen_frontend_action.cpp
@@ -26,17 +26,17 @@ bool BindgenFrontendAction::BeginSourceFileAction(clang::CompilerInstance &ci)
 {
 	clang::Preprocessor &preprocessor = ci.getPreprocessor();
 #if __clang_major__ >= 10
-	preprocessor.addPPCallbacks(std::make_unique<PreprocessorHandler>(this->m_macros, preprocessor));
+	preprocessor.addPPCallbacks(std::make_unique<PreprocessorHandler>(this->m_document, preprocessor));
 #else
-	preprocessor.addPPCallbacks(llvm::make_unique<PreprocessorHandler>(this->m_macros, preprocessor));
+	preprocessor.addPPCallbacks(llvm::make_unique<PreprocessorHandler>(this->m_document, preprocessor));
 #endif
 	return true;
 }
 
 std::unique_ptr<clang::ASTConsumer> BindgenFrontendAction::CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef file) {
 #if __clang_major__ >= 10
-	return std::make_unique<BindgenASTConsumer>(this->m_macros, ci);
+	return std::make_unique<BindgenASTConsumer>(this->m_document, ci);
 #else
-	return llvm::make_unique<BindgenASTConsumer>(this->m_macros, ci);
+	return llvm::make_unique<BindgenASTConsumer>(this->m_document, ci);
 #endif
 }

--- a/clang/src/enum_match_handler.cpp
+++ b/clang/src/enum_match_handler.cpp
@@ -1,12 +1,10 @@
 #include "common.hpp"
 #include "enum_match_handler.hpp"
 
-EnumMatchHandler::EnumMatchHandler(const std::string &name) {
+EnumMatchHandler::EnumMatchHandler(Document &doc, const std::string &name)
+	: m_document(doc)
+{
 	this->m_enum.name = name;
-}
-
-Enum EnumMatchHandler::enumeration() const {
-	return this->m_enum;
 }
 
 void EnumMatchHandler::run(const clang::ast_matchers::MatchFinder::MatchResult &Result) {
@@ -25,6 +23,8 @@ void EnumMatchHandler::runOnEnum(const clang::EnumDecl *enumeration) {
 		int64_t value = field->getInitVal().getExtValue();
 		this->m_enum.values.push_back(std::make_pair(name, value));
 	}
+
+	this->m_document.enums[this->m_enum.name] = this->m_enum;
 }
 
 void EnumMatchHandler::runOnTypedef(const clang::TypedefNameDecl *typeDecl) {

--- a/clang/src/function_match_handler.cpp
+++ b/clang/src/function_match_handler.cpp
@@ -4,8 +4,8 @@
 
 static llvm::cl::opt<std::string> FunctionRegex("f", llvm::cl::desc("Functions to inspect"), llvm::cl::value_desc("function regex"));
 
-FunctionMatchHandler::FunctionMatchHandler()
-	: m_regex(FunctionRegex)
+FunctionMatchHandler::FunctionMatchHandler(Document &doc)
+	: m_document(doc), m_regex(FunctionRegex)
 {
 }
 
@@ -53,6 +53,6 @@ void FunctionMatchHandler::runOnFunction(const clang::FunctionDecl *func) {
 	std::string fullName = func->getQualifiedNameAsString();
 
 	if (isFunctionInteresting(fullName)) {
-		this->m_functions.push_back(buildMethod(func, fullName));
+		this->m_document.functions.push_back(buildMethod(func, fullName));
 	}
 }

--- a/clang/src/preprocessor_handler.cpp
+++ b/clang/src/preprocessor_handler.cpp
@@ -8,8 +8,8 @@
 
 static llvm::cl::opt<std::string> MacroChecker("m", llvm::cl::desc("Macros to copy"), llvm::cl::value_desc("regex"));
 
-PreprocessorHandler::PreprocessorHandler(std::vector<Macro> &macros, clang::Preprocessor &preprocessor)
-		: m_preprocessor(preprocessor), m_macros(macros), m_regex(MacroChecker)
+PreprocessorHandler::PreprocessorHandler(Document &doc, clang::Preprocessor &preprocessor)
+		: m_preprocessor(preprocessor), m_document(doc), m_regex(MacroChecker)
 {
 }
 
@@ -31,7 +31,7 @@ void PreprocessorHandler::MacroDefined(const clang::Token &token, const clang::M
   m.name = name;
 
   if (initializeMacro(m, token, md)) {
-    this->m_macros.push_back(m);
+    this->m_document.macros.push_back(m);
   }
 }
 

--- a/clang/src/record_match_handler.cpp
+++ b/clang/src/record_match_handler.cpp
@@ -2,12 +2,10 @@
 #include "record_match_handler.hpp"
 #include "type_helper.hpp"
 
-RecordMatchHandler::RecordMatchHandler(const std::string &name) {
+RecordMatchHandler::RecordMatchHandler(Document &doc, const std::string &name)
+	: m_document(doc)
+{
 	this->m_class.name = name;
-}
-
-Class RecordMatchHandler::klass() const {
-  return this->m_class;
 }
 
 void RecordMatchHandler::run(const clang::ast_matchers::MatchFinder::MatchResult &result) {
@@ -76,6 +74,7 @@ void RecordMatchHandler::runOnRecord(const clang::CXXRecordDecl *record) {
 
 	bool isPublic = record->isStruct(); // Default public for structs!
 	bool isSignal = false; // Qt signal support
+
 	for (clang::Decl *decl : record->decls()) {
 		if (clang::CXXMethodDecl *method = llvm::dyn_cast<clang::CXXMethodDecl>(decl)) {
 			runOnMethod(method, isSignal);
@@ -85,6 +84,8 @@ void RecordMatchHandler::runOnRecord(const clang::CXXRecordDecl *record) {
 			runOnField(field);
 		}
 	}
+
+	this->m_document.classes[this->m_class.name] = this->m_class;
 }
 
 void RecordMatchHandler::runOnField(const clang::FieldDecl *field) {

--- a/clang/src/structures.cpp
+++ b/clang/src/structures.cpp
@@ -230,3 +230,14 @@ JsonStream &operator<<(JsonStream &s, const Macro &value) {
 	s << JsonStream::ObjectEnd;
 	return s;
 }
+
+JsonStream &operator<<(JsonStream &s, const Document &value) {
+	auto c = JsonStream::Comma;
+	return s
+		<< JsonStream::ObjectBegin
+		<< std::make_pair("enums", value.enums) << c
+		<< std::make_pair("classes", value.classes) << c
+		<< std::make_pair("functions", value.functions) << c
+		<< std::make_pair("macros", value.macros)
+		<< JsonStream::ObjectEnd;
+}


### PR DESCRIPTION
This refactor brings the equivalent of Crystal's `Bindgen::Parser::Document` to the Clang parser.

Alone it doesn't do anything new, but passing the whole document around allows each registered AST handler to insert multiple parser values (there will be a use case for this).