### PR TITLE
Regression: maintain object key order of parser document JSON

### DIFF
--- a/clang/include/json_stream.hpp
+++ b/clang/include/json_stream.hpp
@@ -101,4 +101,39 @@ private:
 	std::ostream &m_out;
 };
 
+// An associative array which, when serialized to JSON, maintains the insertion
+// order of its elements.
+template< typename K, typename V >
+class JsonMap {
+public:
+	V &operator[](const K &key) {
+		if (m_map.find(key) == m_map.end())
+			m_keys.push_back(key);
+		return m_map[key];
+	}
+
+	JsonStream &toJson(JsonStream &s) const {
+		bool first = true;
+		s << JsonStream::ObjectBegin;
+
+		for (const auto &k : m_keys) {
+			if (!first) s << JsonStream::Comma;
+			s << *m_map.find(k);
+			first = false;
+		}
+
+		s << JsonStream::ObjectEnd;
+		return s;
+	}
+
+private:
+	std::map<K, V> m_map;
+	std::vector<K> m_keys;
+};
+
+template< typename K, typename V >
+JsonStream &operator<<(JsonStream &s, const JsonMap<K, V> &value) {
+	return value.toJson(s);
+}
+
 #endif // JSON_STREAM_HPP

--- a/clang/include/structures.hpp
+++ b/clang/include/structures.hpp
@@ -175,8 +175,8 @@ struct Macro {
 JsonStream &operator<<(JsonStream &s, const Macro &value);
 
 struct Document {
-	std::map<std::string, Enum> enums;
-	std::map<std::string, Class> classes;
+	JsonMap<std::string, Enum> enums;
+	JsonMap<std::string, Class> classes;
 	std::vector<Method> functions;
 	std::vector<Macro> macros;
 };


### PR DESCRIPTION
Follow-up to #84.

Some processors rely on the object key order of the JSON document generated by the Clang parser; most notably, the Crystal wrapper generators assume that every class appears before its subclasses, so that subclasses never inherit from undefined base classes. This class order is directly derived from the Clang parser. However, using `std::map` means the keys are always sorted in alphabetical order, so code like below breaks because `A` will be added to the JSON before `B`:

```cpp
struct B { };
struct A : B { };
```

```crystal
# cannot use `B` before it is defined
class A < B
end

class B
end
```

The simplest fix is to use a custom `std::map`-like container in the `Document` struct that keeps track of the key insertion order. This patch requires no changes on the Crystal side.