### PR TITLE
DefaultConstructor: more robust detection of default-constructible types

### DIFF
--- a/assets/parser_helper.hpp
+++ b/assets/parser_helper.hpp
@@ -1,0 +1,6 @@
+#include <type_traits>
+
+template< typename T >
+struct BindgenTypeInfo {
+  static const bool isDefaultConstructible = std::is_default_constructible<T>::value;
+};

--- a/clang/include/bindgen_ast_consumer.hpp
+++ b/clang/include/bindgen_ast_consumer.hpp
@@ -14,7 +14,7 @@ public:
 	void HandleTranslationUnit(clang::ASTContext &ctx) override;
 
 private:
-
+	void gatherTypeInfo(clang::ASTContext &ctx);
 	void evaluateMacros(clang::ASTContext &ctx);
 	void serializeAndOutput();
 

--- a/clang/include/clang_type_name.hpp
+++ b/clang/include/clang_type_name.hpp
@@ -63,6 +63,9 @@ SOFTWARE.
  //
  //===----------------------------------------------------------------------===//
 
+#ifndef CLANG_TYPE_NAME_HPP
+#define CLANG_TYPE_NAME_HPP
+
 # if __clang_major__ < 6
  #include "clang/Tooling/Core/QualTypeNames.h"
 # else
@@ -521,9 +524,9 @@ namespace ClangTypeName {
    return QT;
  }
 
- std::string getFullyQualifiedName(QualType QT,
-                                   const ASTContext &Ctx,
-                                   bool WithGlobalNsPrefix = false) {
+ static std::string getFullyQualifiedName(QualType QT,
+                                          const ASTContext &Ctx,
+                                          bool WithGlobalNsPrefix = false) {
    PrintingPolicy Policy(Ctx.getPrintingPolicy());
    Policy.SuppressScope = false;
    Policy.AnonymousTagLocations = false;
@@ -535,3 +538,5 @@ namespace ClangTypeName {
  }
 
 }  // end namespace ClangTypeName
+
+#endif // CLANG_TYPE_NAME_HPP

--- a/clang/include/clang_type_name_llvm_8.hpp
+++ b/clang/include/clang_type_name_llvm_8.hpp
@@ -63,6 +63,9 @@ SOFTWARE.
  //
  //===----------------------------------------------------------------------===//
 
+#ifndef CLANG_TYPE_NAME_HPP
+#define CLANG_TYPE_NAME_HPP
+
  #include "clang/AST/QualTypeNames.h"
  #include "clang/AST/DeclTemplate.h"
  #include "clang/AST/DeclarationName.h"
@@ -516,9 +519,9 @@ namespace ClangTypeName {
    return QT;
  }
 
- std::string getFullyQualifiedName(QualType QT,
-                                   const ASTContext &Ctx,
-                                   bool WithGlobalNsPrefix = false) {
+ static std::string getFullyQualifiedName(QualType QT,
+                                          const ASTContext &Ctx,
+                                          bool WithGlobalNsPrefix = false) {
    PrintingPolicy Policy(Ctx.getPrintingPolicy());
    Policy.SuppressScope = false;
    Policy.AnonymousTagLocations = false;
@@ -530,3 +533,5 @@ namespace ClangTypeName {
  }
 
 }  // end namespace ClangTypeName
+
+#endif // CLANG_TYPE_NAME_HPP

--- a/clang/include/structures.hpp
+++ b/clang/include/structures.hpp
@@ -175,11 +175,23 @@ struct Macro {
 
 JsonStream &operator<<(JsonStream &s, const Macro &value);
 
+// type properties gathered from instantiations of `BindgenTypeInfo`
+struct TypeInfoResult {
+	bool isDefaultConstructible;
+};
+
 struct Document {
 	JsonMap<std::string, Enum> enums;
 	JsonMap<std::string, Class> classes;
 	std::vector<Method> functions;
 	std::vector<Macro> macros;
+
+	std::map<std::string, TypeInfoResult> type_infos; // not serialized
+
+	TypeInfoResult *findTypeInfoResult(const std::string &klass) {
+		auto it = type_infos.find(klass);
+		return it != type_infos.end() ? &it->second : nullptr;
+	}
 };
 
 JsonStream &operator<<(JsonStream &s, const Document &value);

--- a/clang/src/record_match_handler.cpp
+++ b/clang/src/record_match_handler.cpp
@@ -75,7 +75,10 @@ bool RecordMatchHandler::runOnMethod(Method &m, Class &klass, const clang::CXXMe
 }
 
 bool RecordMatchHandler::runOnRecord(Class &klass, const clang::CXXRecordDecl *record) {
-	klass.hasDefaultConstructor = record->hasDefaultConstructor();
+	const auto *typeInfoResult = m_document.findTypeInfoResult(klass.name);
+
+	klass.hasDefaultConstructor = record->hasDefaultConstructor() &&
+		!(typeInfoResult && !typeInfoResult->isDefaultConstructible);
 	klass.hasCopyConstructor = record->hasCopyConstructorWithConstParam();
 	klass.isAbstract = record->isAbstract();
 	klass.isClass = record->isClass();

--- a/clang/src/record_match_handler.cpp
+++ b/clang/src/record_match_handler.cpp
@@ -32,6 +32,9 @@ void RecordMatchHandler::run(const clang::ast_matchers::MatchFinder::MatchResult
 }
 
 bool RecordMatchHandler::runOnMethod(Method &m, Class &klass, const clang::CXXMethodDecl *method, bool isSignal) {
+	if (method->isDeleted())
+		return false;
+
 	m.className = method->getParent()->getQualifiedNameAsString();
 	m.isConst = method->isConst();
 	m.isVirtual = method->isVirtual();

--- a/spec/integration/basic.cpp
+++ b/spec/integration/basic.cpp
@@ -53,5 +53,12 @@ public:
 };
 
 struct ImplicitConstructor {
-  int itWorks() { return 1; }
+};
+
+class PrivateConstructor {
+  PrivateConstructor();
+};
+
+struct DeletedConstructor {
+  DeletedConstructor() = delete;
 };

--- a/spec/integration/basic.yml
+++ b/spec/integration/basic.yml
@@ -5,6 +5,8 @@
 classes:
   Adder: AdderWrap
   ImplicitConstructor: ImplicitConstructor
+  PrivateConstructor: PrivateConstructor
+  DeletedConstructor: DeletedConstructor
   TypeConversion: TypeConversion
 
 types:

--- a/spec/integration/basic_spec.cr
+++ b/spec/integration/basic_spec.cr
@@ -13,9 +13,26 @@ describe "a basic C++ wrapper" do
         end
       end
 
-      context "if class has implicit default constructor" do
-        it "has a default constructor" do
-          Test::ImplicitConstructor.new.it_works.should eq(1)
+      context "argument-less default constructor" do
+        it "is generated if class is default-constructible" do
+          {{
+            Test::ImplicitConstructor.methods.any? do |m|
+              m.name == "initialize" && m.args.empty?
+            end
+          }}.should be_true
+        end
+
+        it "is omitted if class is not default-constructible" do
+          {{
+            Test::PrivateConstructor.methods.any? do |m|
+              m.name == "initialize" && m.args.empty?
+            end
+          }}.should be_false
+          {{
+            Test::DeletedConstructor.methods.any? do |m|
+              m.name == "initialize" && m.args.empty?
+            end
+          }}.should be_false
         end
       end
 

--- a/src/bindgen/parser/runner.cr
+++ b/src/bindgen/parser/runner.cr
@@ -55,6 +55,11 @@ module Bindgen
             file.puts %{#include #{path.inspect}}
           end
 
+          file.puts %{#include "#{File.expand_path "#{__DIR__}/../../../assets/parser_helper.hpp"}"}
+          @classes.each do |klass|
+            file.puts %[template class BindgenTypeInfo<#{klass}>;]
+          end
+
           file.flush
           result = yield file.path
         end

--- a/src/bindgen/processor/default_constructor.cr
+++ b/src/bindgen/processor/default_constructor.cr
@@ -7,7 +7,6 @@ module Bindgen
         return unless klass.origin.has_default_constructor?
         return if klass.wrapped_class # Skip `Impl` classes.
         return if has_default_initialize?(klass)
-        return if has_private_constructor?(klass.origin)
 
         ctor = build_default_constructor(klass.origin)
 
@@ -44,16 +43,6 @@ module Bindgen
 
         # Found?
         required == 0
-      end
-
-      private def has_private_constructor?(klass)
-        ctor = klass.methods.find { |method| default_constructor? method }
-
-        if ctor
-          ctor.private?
-        else
-          false # Doesn't exist: Not private.
-        end
       end
     end
   end


### PR DESCRIPTION
Currently the `DefaultConstructor` processor checks for private default constructors, but misses out other situations where the default ctor would be deleted (`= delete`, const / reference data member etc.), and Clang doesn't report these cases either. This patch fixes it by using `std::is_default_constructible` itself to check whether a given type is default-constructible. The steps are:

* The `BindgenTypeInfo<T>` class template contains all compile-time type info necessary for a given type; it is never used during runtime. Currently it only holds a single member indicating whether `T` is default-constructible.
* The temporary .cpp input file generated by Bindgen `#include`s this class template, and explicitly instantiates the template for every class considered by the config files.
* The member values for each instantiated type will become available to the Clang parser, so each class handler knows whether a given `T` is truly default-constructible or not.

For example, the temporary file for `basic_spec.cpp` will look like:

```cpp
#include "basic.cpp"
#include "/.../assets/parser_helper.hpp"
template class BindgenTypeInfo<Adder>;
template class BindgenTypeInfo<ImplicitConstructor>;
template class BindgenTypeInfo<PrivateConstructor>;
template class BindgenTypeInfo<DeletedConstructor>;
template class BindgenTypeInfo<TypeConversion>;
```

This avoids the need to reimplement default ctor detection on the Crystal side (not even private ctor checking). The same technique may be used to check for other C++ compile-time properties inside `BindgenTypeInfo`.