### PR TITLE
Add support for C unions

### DIFF
--- a/clang/include/structures.hpp
+++ b/clang/include/structures.hpp
@@ -139,7 +139,10 @@ struct Field : public Type {
 JsonStream &operator<<(JsonStream &s, const Field &value);
 
 struct Class {
+	// The following are mutually exclusive
 	bool isClass; // Class or struct?
+	bool isUnion; // Union or struct?
+
 	bool hasDefaultConstructor;
 	bool hasCopyConstructor;
 	bool isDestructible = true; // Does this class have a public or protected destructor?

--- a/clang/include/structures.hpp
+++ b/clang/include/structures.hpp
@@ -138,11 +138,10 @@ struct Field : public Type {
 
 JsonStream &operator<<(JsonStream &s, const Field &value);
 
-struct Class {
-	// The following are mutually exclusive
-	bool isClass; // Class or struct?
-	bool isUnion; // Union or struct?
+JsonStream &operator<<(JsonStream &s, clang::TagTypeKind value);
 
+struct Class {
+	clang::TagTypeKind typeKind; // Class, struct, or union?
 	bool hasDefaultConstructor;
 	bool hasCopyConstructor;
 	bool isDestructible = true; // Does this class have a public or protected destructor?

--- a/clang/src/record_match_handler.cpp
+++ b/clang/src/record_match_handler.cpp
@@ -84,8 +84,7 @@ bool RecordMatchHandler::runOnRecord(Class &klass, const clang::CXXRecordDecl *r
 		!(typeInfoResult && !typeInfoResult->isDefaultConstructible);
 	klass.hasCopyConstructor = record->hasCopyConstructorWithConstParam();
 	klass.isAbstract = record->isAbstract();
-	klass.isClass = record->isClass();
-	klass.isUnion = record->isUnion();
+	klass.typeKind = record->getTagKind();
 
 	clang::TypeInfo typeInfo = record->getASTContext().getTypeInfo(record->getTypeForDecl());
 	uint64_t bitSize = typeInfo.Width;

--- a/clang/src/record_match_handler.cpp
+++ b/clang/src/record_match_handler.cpp
@@ -85,6 +85,7 @@ bool RecordMatchHandler::runOnRecord(Class &klass, const clang::CXXRecordDecl *r
 	klass.hasCopyConstructor = record->hasCopyConstructorWithConstParam();
 	klass.isAbstract = record->isAbstract();
 	klass.isClass = record->isClass();
+	klass.isUnion = record->isUnion();
 
 	clang::TypeInfo typeInfo = record->getASTContext().getTypeInfo(record->getTypeForDecl());
 	uint64_t bitSize = typeInfo.Width;

--- a/clang/src/structures.cpp
+++ b/clang/src/structures.cpp
@@ -183,6 +183,7 @@ JsonStream &operator<<(JsonStream &s, const Class &value) {
 		<< std::make_pair("name", value.name) << c
 		<< std::make_pair("byteSize", value.byteSize) << c
 		<< std::make_pair("isClass", value.isClass) << c
+		<< std::make_pair("isUnion", value.isUnion) << c
 		<< std::make_pair("isAbstract", value.isAbstract) << c
 		<< std::make_pair("isAnonymous", value.isAnonymous) << c
 		<< std::make_pair("isDestructible", value.isDestructible) << c

--- a/clang/src/structures.cpp
+++ b/clang/src/structures.cpp
@@ -176,14 +176,24 @@ JsonStream &operator<<(JsonStream &s, const Field &value) {
 	return s << JsonStream::ObjectEnd;
 }
 
+JsonStream &operator<<(JsonStream &s, clang::TagTypeKind value) {
+	switch (value) {
+		case clang::TTK_Class: return s << "Class";
+		case clang::TTK_Struct: return s << "Struct";
+		case clang::TTK_Union: return s << "CppUnion"; // avoid confusion with Crystal union
+		case clang::TTK_Interface: return s << "Interface";
+		case clang::TTK_Enum: return s << "Enum";
+		default: return s << "BUG IN Bindgen";
+	}
+}
+
 JsonStream &operator<<(JsonStream &s, const Class &value) {
 	auto c = JsonStream::Comma;
 	return s
 		<< JsonStream::ObjectBegin
 		<< std::make_pair("name", value.name) << c
 		<< std::make_pair("byteSize", value.byteSize) << c
-		<< std::make_pair("isClass", value.isClass) << c
-		<< std::make_pair("isUnion", value.isUnion) << c
+		<< std::make_pair("typeKind", value.typeKind) << c
 		<< std::make_pair("isAbstract", value.isAbstract) << c
 		<< std::make_pair("isAnonymous", value.isAnonymous) << c
 		<< std::make_pair("isDestructible", value.isDestructible) << c

--- a/spec/integration/copy_structs.cpp
+++ b/spec/integration/copy_structs.cpp
@@ -55,6 +55,13 @@ struct Wrapped {
 
 
 
+union PlainUnion {
+  int x;
+  float y;
+};
+
+
+
 class Props {
 public:
   Props(int x, int y) :

--- a/spec/integration/copy_structs.cpp
+++ b/spec/integration/copy_structs.cpp
@@ -123,6 +123,19 @@ private:
   const int y_priv;
 };
 
+class NestedProtected {
+protected:
+  struct {
+    int x;
+  };
+};
+
+class NestedPrivate {
+  struct {
+    int x;
+  };
+};
+
 struct ConfigIgnoreAll {
   const int a, b;
 };

--- a/spec/integration/copy_structs.cpp
+++ b/spec/integration/copy_structs.cpp
@@ -60,6 +60,42 @@ union PlainUnion {
   float y;
 };
 
+// neither union should be inlined
+struct UnionInStruct {
+  union {
+    char a;
+    int b;
+  } u;
+  union {
+    float c;
+    bool d;
+  };
+};
+
+// neither struct should be inlined
+union StructInUnion {
+  struct {
+    char a;
+    int b;
+  } s;
+  struct {
+    float c;
+    bool d;
+  };
+};
+
+// c and d can be inlined
+union NestedUnion {
+  union {
+    char a; // .u.a
+    int b; // .u.b
+  } u;
+  union {
+    float c; // .c
+    bool d; // .d
+  };
+};
+
 
 
 class Props {

--- a/spec/integration/copy_structs.yml
+++ b/spec/integration/copy_structs.yml
@@ -12,6 +12,9 @@ classes:
   Anonymous: Anonymous
   Wrapped: Wrapped
   PlainUnion: PlainUnion
+  UnionInStruct: UnionInStruct
+  StructInUnion: StructInUnion
+  NestedUnion: NestedUnion
 
 types:
   Point: { copy_structure: true, generate_binding: false, generate_wrapper: false }
@@ -22,3 +25,6 @@ types:
   Nested::Inner2: { copy_structure: true, generate_binding: false, generate_wrapper: false }
   Anonymous: { copy_structure: true, generate_binding: false, generate_wrapper: false }
   PlainUnion: { copy_structure: true, generate_binding: false, generate_wrapper: false }
+  UnionInStruct: { copy_structure: true, generate_binding: false, generate_wrapper: false }
+  StructInUnion: { copy_structure: true, generate_binding: false, generate_wrapper: false }
+  NestedUnion: { copy_structure: true, generate_binding: false, generate_wrapper: false }

--- a/spec/integration/copy_structs.yml
+++ b/spec/integration/copy_structs.yml
@@ -11,6 +11,7 @@ classes:
   Nested::Inner2: Nested::Inner2
   Anonymous: Anonymous
   Wrapped: Wrapped
+  PlainUnion: PlainUnion
 
 types:
   Point: { copy_structure: true, generate_binding: false, generate_wrapper: false }
@@ -20,3 +21,4 @@ types:
   Nested::Inner: { copy_structure: true, generate_binding: false, generate_wrapper: false }
   Nested::Inner2: { copy_structure: true, generate_binding: false, generate_wrapper: false }
   Anonymous: { copy_structure: true, generate_binding: false, generate_wrapper: false }
+  PlainUnion: { copy_structure: true, generate_binding: false, generate_wrapper: false }

--- a/spec/integration/copy_structs_spec.cr
+++ b/spec/integration/copy_structs_spec.cr
@@ -28,6 +28,13 @@ describe "copied structure functionality" do
           subject.before.should eq(Pointer(Test::Binding::PolyLine).null)
           subject.after.should eq(Pointer(Test::Binding::PolyLine).null)
         end
+
+        it "supports unions" do
+          subject = Test::Binding::PlainUnion.new
+          instance_var_names(subject).should eq(%w{x y})
+          subject.x = 1_f32.unsafe_as(Int32)
+          subject.y.should eq(1_f32)
+        end
       end
 
       context "nested types" do

--- a/spec/integration/instance_properties.yml
+++ b/spec/integration/instance_properties.yml
@@ -2,6 +2,7 @@
 
 processors:
   - filter_methods
+  - default_constructor
   - instance_properties
   - crystal_wrapper
   - cpp_wrapper
@@ -10,8 +11,9 @@ processors:
 
 classes:
   Point: Point
-  Anonymous: Anonymous # if it compiles, it works
+  Anonymous: Anonymous
   Props: Props
+  PlainUnion: PlainUnion
   ConfigIgnoreAll: ConfigIgnoreAll
   ConfigIgnore: ConfigIgnore
   ConfigRename: ConfigRename

--- a/spec/integration/instance_properties.yml
+++ b/spec/integration/instance_properties.yml
@@ -18,6 +18,8 @@ classes:
   ConfigIgnore: ConfigIgnore
   ConfigRename: ConfigRename
   ConfigNilable: ConfigNilable
+  NestedProtected: NestedProtected
+  NestedPrivate: NestedPrivate
 
 types:
   Point:

--- a/spec/integration/instance_properties_spec.cr
+++ b/spec/integration/instance_properties_spec.cr
@@ -63,10 +63,6 @@ describe "C++ instance properties" do
           position.x.should eq(13)
           position.y.should eq(35)
         end
-
-        it "supports direct members inside nested anonymous types" do
-          {{ Test::Anonymous.has_method?("x0") }}.should be_true
-        end
       end
 
       context "setter methods" do
@@ -118,6 +114,7 @@ describe "C++ instance properties" do
           got.x.should eq(60)
           got.y.should eq(61)
         end
+      end
 
       context "C++ unions" do
         it "works" do
@@ -131,9 +128,31 @@ describe "C++ instance properties" do
 
       context "nested members" do
         it "supports direct members inside nested anonymous types" do
-          subject = Test::Anonymous.new
-          subject.x0 = 5
-          subject.x0.should eq(5)
+          {{ Test::Anonymous.has_method?("x0") }}.should be_true
+          {{ Test::Anonymous.has_method?("x0=") }}.should be_true
+        end
+
+        it "supports public nested fields" do
+          {% begin %}
+            {% method = Test::Anonymous.methods.find &.name.== "x0" %}
+            {{ method.visibility }}.should eq(:public)
+            {% method = Test::Anonymous.methods.find &.name.== "x0=" %}
+            {{ method.visibility }}.should eq(:public)
+          {% end %}
+        end
+
+        it "supports public fields nested inside protected members" do
+          {% begin %}
+            {% method = Test::NestedProtected.methods.find &.name.== "x" %}
+            {{ method.visibility }}.should eq(:private)
+            {% method = Test::NestedProtected.methods.find &.name.== "x=" %}
+            {{ method.visibility }}.should eq(:private)
+          {% end %}
+        end
+
+        it "ignores public fields nested inside private members" do
+          {{ Test::NestedPrivate.has_method?("x") }}.should be_false
+          {{ Test::NestedPrivate.has_method?("x=") }}.should be_false
         end
       end
 

--- a/spec/integration/instance_properties_spec.cr
+++ b/spec/integration/instance_properties_spec.cr
@@ -63,6 +63,10 @@ describe "C++ instance properties" do
           position.x.should eq(13)
           position.y.should eq(35)
         end
+
+        it "supports direct members inside nested anonymous types" do
+          {{ Test::Anonymous.has_method?("x0") }}.should be_true
+        end
       end
 
       context "setter methods" do
@@ -113,6 +117,23 @@ describe "C++ instance properties" do
           got = props.position_val
           got.x.should eq(60)
           got.y.should eq(61)
+        end
+
+      context "C++ unions" do
+        it "works" do
+          u = Test::PlainUnion.new
+          u.x = 123
+          u.y.should eq(123.unsafe_as(Float32))
+          u.y = 123_f32
+          u.x.should eq(123_f32.unsafe_as(Int32))
+        end
+      end
+
+      context "nested members" do
+        it "supports direct members inside nested anonymous types" do
+          subject = Test::Anonymous.new
+          subject.x0 = 5
+          subject.x0.should eq(5)
         end
       end
 

--- a/src/bindgen/generator/crystal_lib.cr
+++ b/src/bindgen/generator/crystal_lib.cr
@@ -38,8 +38,8 @@ module Bindgen
         write_structure(structure, true)
       end
 
-      private def write_structure(structure, c_union : Bool)
-        puts "#{c_union ? "union" : "struct"} #{structure.name}"
+      private def write_structure(structure, cpp_union : Bool)
+        puts "#{cpp_union ? "union" : "struct"} #{structure.name}"
         indented do
           structure.fields.each do |name, result|
             # can't use Void as a struct field type directly

--- a/src/bindgen/generator/crystal_lib.cr
+++ b/src/bindgen/generator/crystal_lib.cr
@@ -31,7 +31,7 @@ module Bindgen
       end
 
       def visit_struct(structure)
-        puts "struct #{structure.name}"
+        puts "#{structure.c_union? ? "union" : "struct"} #{structure.name}"
         indented do
           structure.fields.each do |name, result|
             # can't use Void as a struct field type directly

--- a/src/bindgen/generator/crystal_lib.cr
+++ b/src/bindgen/generator/crystal_lib.cr
@@ -31,7 +31,15 @@ module Bindgen
       end
 
       def visit_struct(structure)
-        puts "#{structure.c_union? ? "union" : "struct"} #{structure.name}"
+        write_structure(structure, false)
+      end
+
+      def visit_union(structure)
+        write_structure(structure, true)
+      end
+
+      private def write_structure(structure, c_union : Bool)
+        puts "#{c_union ? "union" : "struct"} #{structure.name}"
         indented do
           structure.fields.each do |name, result|
             # can't use Void as a struct field type directly

--- a/src/bindgen/graph/class.cr
+++ b/src/bindgen/graph/class.cr
@@ -33,8 +33,9 @@ module Bindgen
       # Is this class abstract?
       property? abstract : Bool = false
 
-      # If the structure of this class is copied, the `Struct` node.
-      property structure : Struct?
+      # If the structure of this class is copied, the `Struct` or `CppUnion`
+      # node.
+      property structure : (Struct | CppUnion)?
 
       # Crystal instance vars in this class.  Will be ignored by the C++ code
       # paths.

--- a/src/bindgen/graph/cpp_union.cr
+++ b/src/bindgen/graph/cpp_union.cr
@@ -1,0 +1,13 @@
+module Bindgen
+  module Graph
+    # A `lib union` in Crystal, or a plain `union` in C/C++.
+    class CppUnion < Container
+      # Variant members in this structure.
+      getter fields : Hash(String, Call::Result)
+
+      def initialize(@fields, name, parent)
+        super(name, parent)
+      end
+    end
+  end
+end

--- a/src/bindgen/graph/struct.cr
+++ b/src/bindgen/graph/struct.cr
@@ -1,7 +1,6 @@
 module Bindgen
   module Graph
-    # A `struct` in Crystal (`lib` or not), or a plain `struct` in C++.  Also
-    # represents a `lib union`.
+    # A `struct` in Crystal (`lib` or not), or a plain `struct` in C++.
     #
     # A structure can host both raw variable fields (C-style) and other methods
     # at once.
@@ -16,10 +15,7 @@ module Bindgen
       # generate the jump-table.
       property base_class : String?
 
-      # Does this structure represent a C union?
-      getter? c_union : Bool
-
-      def initialize(@fields, name, parent, @base_class = nil, union @c_union = false)
+      def initialize(@fields, name, parent, @base_class = nil)
         super(name, parent)
       end
     end

--- a/src/bindgen/graph/struct.cr
+++ b/src/bindgen/graph/struct.cr
@@ -1,6 +1,7 @@
 module Bindgen
   module Graph
-    # A `struct` in Crystal (`lib` or not), or a plain `struct` in C++.
+    # A `struct` in Crystal (`lib` or not), or a plain `struct` in C++.  Also
+    # represents a `lib union`.
     #
     # A structure can host both raw variable fields (C-style) and other methods
     # at once.
@@ -8,14 +9,17 @@ module Bindgen
       # Used to signal the `Generator::Cpp` to generate a `using BASE::BASE;`.
       INHERIT_CONSTRUCTORS_TAG = "INHERIT_CONSTRUCTORS_TAG"
 
-      # Fields in this struct.
+      # Fields in this structure.
       getter fields : Hash(String, Call::Result)
 
       # Name of the base-class, if any.  This is mainly useful for C++ to
       # generate the jump-table.
       property base_class : String?
 
-      def initialize(@fields, name, parent, @base_class = nil)
+      # Does this structure represent a C union?
+      getter? c_union : Bool
+
+      def initialize(@fields, name, parent, @base_class = nil, union @c_union = false)
         super(name, parent)
       end
     end

--- a/src/bindgen/graph/visitor.cr
+++ b/src/bindgen/graph/visitor.cr
@@ -35,23 +35,25 @@ module Bindgen
 
         case node
         when Graph::Alias
-          visit_alias(node.as(Graph::Alias))
+          visit_alias(node)
         when Graph::Class
-          visit_class(node.as(Graph::Class))
+          visit_class(node)
         when Graph::Constant
-          visit_constant(node.as(Graph::Constant))
+          visit_constant(node)
         when Graph::Enum
-          visit_enum(node.as(Graph::Enum))
+          visit_enum(node)
         when Graph::Library
-          visit_library(node.as(Graph::Library))
+          visit_library(node)
         when Graph::Method
-          visit_method(node.as(Graph::Method))
+          visit_method(node)
         when Graph::Namespace
-          visit_namespace(node.as(Graph::Namespace))
+          visit_namespace(node)
         when Graph::Struct
-          visit_struct(node.as(Graph::Struct))
+          visit_struct(node)
+        when Graph::CppUnion
+          visit_union(node)
         when Graph::PlatformSpecific
-          visit_platform_specific(node.as(Graph::PlatformSpecific))
+          visit_platform_specific(node)
         else
           raise "BUG: Missing case for type #{node.class} in Graph::Visitor"
         end
@@ -100,6 +102,11 @@ module Bindgen
 
       # Visits a `Graph::Struct`.
       def visit_struct(structure)
+        visit_children(structure)
+      end
+
+      # Visits a `Graph::CppUnion`.
+      def visit_union(structure)
         visit_children(structure)
       end
 

--- a/src/bindgen/parser/type.cr
+++ b/src/bindgen/parser/type.cr
@@ -7,6 +7,7 @@ module Bindgen
       CRYSTAL_PROC = "CrystalProc"
 
       # Type kinds.  Currently not used by the clang tool.
+      # TODO: use `Parser::TypeKind` instead
       enum Kind
         Class
         Struct

--- a/src/bindgen/parser/type_kind.cr
+++ b/src/bindgen/parser/type_kind.cr
@@ -1,0 +1,12 @@
+module Bindgen
+  module Parser
+    # Describes the declaration kind of a C++ type.
+    enum TypeKind
+      Class
+      Struct
+      CppUnion
+      Interface
+      Enum
+    end
+  end
+end

--- a/src/bindgen/processor/copy_structs.cr
+++ b/src/bindgen/processor/copy_structs.cr
@@ -48,7 +48,7 @@ module Bindgen
         name = typename.binding(klass.as_type).first
 
         # Add the struct or union into the graph
-        if klass.c_union?
+        if klass.cpp_union?
           Graph::CppUnion.new(
             name: name,
             fields: fields_to_graph(klass),
@@ -125,7 +125,7 @@ module Bindgen
           false # cannot inline field if its structure isn't copied
         when !node.try(&.origin.anonymous?)
           false # named types are never inlined
-        when klass.c_union? != node.try(&.origin.c_union?)
+        when klass.cpp_union? != node.try(&.origin.cpp_union?)
           false # a C union cannot be inlined inside a struct, and vice-versa
         else
           true

--- a/src/bindgen/processor/copy_structs.cr
+++ b/src/bindgen/processor/copy_structs.cr
@@ -47,6 +47,7 @@ module Bindgen
           name: name,
           fields: fields_to_graph(klass.fields),
           parent: root,
+          union: klass.c_union?,
         )
       end
 

--- a/src/bindgen/processor/function_class.cr
+++ b/src/bindgen/processor/function_class.cr
@@ -113,7 +113,6 @@ module Bindgen
           name: Graph::Path.from(name).last_part,
           hasDefaultConstructor: has_default_constructor?(wrapper.constructors, list),
           hasCopyConstructor: false,
-          isClass: true,
           methods: classify_methods(wrapper, config, list),
           bases: bases,
         )

--- a/src/bindgen/processor/inheritance.cr
+++ b/src/bindgen/processor/inheritance.cr
@@ -193,7 +193,7 @@ module Bindgen
         )
 
         Parser::Class.new(
-          isClass: klass.class?,
+          typeKind: klass.type_kind,
           hasDefaultConstructor: klass.has_default_constructor?,
           hasCopyConstructor: klass.has_copy_constructor?,
           isAbstract: false,

--- a/src/bindgen/processor/instance_properties.cr
+++ b/src/bindgen/processor/instance_properties.cr
@@ -19,6 +19,7 @@ module Bindgen
         klass.origin.each_field do |field|
           # Ignore private fields.  Also ignore all reference fields for now.
           next if field.private? || field.reference? || field.move?
+          next if is_field_anonymous?(field) # Skip anonymous members for now
 
           pattern, config = lookup_member_config(var_config, field.name)
           next if config.ignore
@@ -29,7 +30,6 @@ module Bindgen
           method_name = config.rename ? field.name.gsub(pattern, config.rename) : field.name
           method_name = method_name.underscore
           field_type = config.nilable ? (field.make_pointer_nilable || field) : field
-          next if is_field_anonymous?(field_type) # Skip anonymous members for now
 
           add_getter(klass, access, field_type, field.name, method_name)
           add_setter(klass, access, field_type, field.name, method_name) unless field.const?

--- a/src/bindgen/processor/virtual_override.cr
+++ b/src/bindgen/processor/virtual_override.cr
@@ -93,7 +93,7 @@ module Bindgen
         node = Parser::Class.new(
           name: SUPERCLASS_NAME,
           access: Parser::AccessSpecifier::Private,
-          isClass: false,
+          typeKind: Parser::TypeKind::Struct,
           methods: [] of Parser::Method,
         )
         # TODO: return a Crystal struct instead


### PR DESCRIPTION
C `union`s are distinct from Crystal `Union`s for a few reasons:

* C `union`s are a layout constraint that associates names to each variant member; Crystal `Union`s are a type constraint and cannot do the same.
* C `union`s may use repeated types among variant members, like `button` and `axis` below.
* It is well-defined in C to write to a variant member of a `union` and then read from a different variant member. (This is undefined behaviour in C++ but most compilers use the C behaviour anyway.)

This patch allows C `union`s to have their structures copied or their instance property methods generated. Nested structures are also handled properly. After this PR, a compound structure like

```cpp
typedef struct SDL_GameControllerButtonBind
{
    SDL_GameControllerBindType bindType;
    
    union
    {
        int button;
        int axis;
        struct {
            int hat;
            int hat_mask;
        } hat;
    } value;

} SDL_GameControllerButtonBind;
```

will generate

```crystal
lib Binding
  struct SDLGameControllerButtonBind
    bind_type : SDLGameControllerBindType
    value : SDLGameControllerButtonBind_Unnamed0
  end
  union SDLGameControllerButtonBind_Unnamed0
    button : Int32
    axis : Int32
    hat : SDLGameControllerButtonBind_Unnamed0_Unnamed0
  end
  struct SDLGameControllerButtonBind_Unnamed0_Unnamed0
    hat : Int32
    hat_mask : Int32
  end
end

enum SDLGameControllerBindType
  # ...
end
```

This PR doesn't change how Crystal wrappers are generated for anonymous types, so if `SDL_GameControllerButtonBind` is wrapped, the only property methods available would be `#bind_type` and `#bind_type=`, as `value` will be ignored and its members cannot be inlined.