### PR TITLE
Allow instantiations of nested container types

### DIFF
--- a/spec/integration/containers.cpp
+++ b/spec/integration/containers.cpp
@@ -7,6 +7,10 @@ public:
     return std::vector<int>{ 1, 2, 3 };
   }
 
+  std::vector<std::vector<int>> grid() {
+    return { { 1, 4 }, { 9, 16 } };
+  }
+
   std::vector<std::string> strings() {
     return std::vector<std::string>{ "One", "Two", "Three" };
   }

--- a/spec/integration/containers.yml
+++ b/spec/integration/containers.yml
@@ -19,3 +19,4 @@ containers:
       - [ "int" ]
       - [ "double" ]
       - [ "std::string" ]
+      - [ "std::vector<int>" ]

--- a/spec/integration/containers_spec.cr
+++ b/spec/integration/containers_spec.cr
@@ -16,6 +16,10 @@ describe "container instantiation feature" do
           list = [1.5, 2.5]
           Test::Containers.new.sum(list).should eq(4.0)
         end
+
+        it "works with nested containers" do
+          Test::Containers.new.grid.to_a.map(&.to_a).should eq([[1, 4], [9, 16]])
+        end
       end
     end
   end

--- a/src/bindgen/cpp/pass.cr
+++ b/src/bindgen/cpp/pass.cr
@@ -39,8 +39,8 @@ module Bindgen
         proc_types = inner_args[1..-1].map { |t| to_crystal(t).as(Call::Result) }
         proc_types.unshift to_cpp(inner_args.first)
 
-        proc_args = typer.full(proc_types).join(", ")
-        "CrystalProc<#{proc_args}>"
+        proc_args = typer.full(proc_types)
+        typer.template_class("CrystalProc", proc_args)
       end
 
       # Computes a result for passing *type* from Crystal to C++.

--- a/src/bindgen/cpp/typename.cr
+++ b/src/bindgen/cpp/typename.cr
@@ -27,6 +27,26 @@ module Bindgen
       def full(results : Enumerable(Call::Expression)) : Array(String)
         results.map { |result| full(result) }
       end
+
+      # Generates the C++ type name of a *template* class with the given
+      # template type *arguments*.
+      def template_class(template : String, arguments : Enumerable(String)) : String
+        String.build do |b|
+          b << template << '<'
+
+          first = true
+          needs_space = false
+          arguments.each do |arg|
+            b << ", " unless first
+            b << arg
+            first = false
+            needs_space = arg.ends_with?('>')
+          end
+
+          b << ' ' if needs_space
+          b << '>'
+        end
+      end
     end
   end
 end

--- a/src/bindgen/processor/instantiate_containers.cr
+++ b/src/bindgen/processor/instantiate_containers.cr
@@ -70,7 +70,8 @@ module Bindgen
       # the alias in the type-database.
       private def add_cpp_typedef(root, klass, container, instance)
         pass = Cpp::Pass.new(@db)
-        type = Parser::Type.parse("#{container.class}<#{instance.join ", "}>")
+        typer = Cpp::Typename.new
+        type = Parser::Type.parse(typer.template_class(container.class, instance))
 
         # Alias e.g. `QList_QObject_X` to `QList<QObject *>`
         if @db[type.base_name]?.nil?
@@ -129,7 +130,8 @@ module Bindgen
 
       # Name of *container* with *instance* for diagnostic purposes.
       private def diagnostics_name(container, instance)
-        "#{container.class}<#{instance.join(", ")}>"
+        typer = Cpp::Typename.new
+        typer.template_class(container.class, instance)
       end
 
       # Checks if *instance* of *container* is valid.  If not, raises.


### PR DESCRIPTION
This small patch ensures that template type names generated by Bindgen in some places do not contain `>>`, to match the Clang parser's output; for example, `std::vector<std::vector<int> >` would be used instead of `std::vector<std::vector<int>>`. It seems this is all it takes to support those nested container types; before this the integration test would fail with an invalid `lib` alias.

The other alternative is to alter the parser itself so that it doesn't add spaces between the `>`s, which are no longer required in C++11. Clang provides [`clang::PrintingPolicy::SplitTemplateClosers`](https://clang.llvm.org/doxygen/structclang_1_1PrintingPolicy.html#a1aa9b0aa468f6669be43c75ebd087ed3), but this doesn't seem to be available on Clang 9 (which I use).