### PR TITLE
Host anonymous enumerators inside wrapped classes as constants

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -563,8 +563,29 @@ Given a `QFlags<ApplicationFlag>`, the generated enumeration will look like
 
 ```cr
 @[Flags]
-enum ApplicationFlag : Int32
+enum ApplicationFlag : UInt32
   # Constants ...
+end
+```
+
+### §5.4 Nested anonymous enums
+
+An unnamed enumeration type inside a wrapped class will dump its enumerators
+into the enclosing wrapper as constants, instead of generating an enumeration.
+The underlying type of the enumeration type is respected.
+
+```cpp
+struct Calculator {
+  enum { PLUS, MINUS, TIMES, DIVIDE };
+};
+```
+
+```crystal
+class Calculator
+  Plus = 0u32
+  Minus = 1u32
+  Times = 2u32
+  Divide = 3u32
 end
 ```
 

--- a/clang/include/enum_match_handler.hpp
+++ b/clang/include/enum_match_handler.hpp
@@ -7,18 +7,18 @@ public:
 
 	virtual void run(const clang::ast_matchers::MatchFinder::MatchResult &Result) override;
 
-	void runOnEnum(const clang::EnumDecl *enumeration);
+	bool runOnEnum(Enum &e, const clang::EnumDecl *enumeration);
 
 	// Support for
 	// 1. typedef'd enum types
 	// 2. Qts `typedef QFlags<ENUM> ENUMs;` paradigm
-	void runOnTypedef(const clang::TypedefNameDecl *typeDecl);
+	bool runOnTypedef(Enum &e, const clang::TypedefNameDecl *typeDecl);
 
-	void handleQFlagsType(const clang::ClassTemplateSpecializationDecl *tmpl);
+	bool handleQFlagsType(Enum &e, const clang::ClassTemplateSpecializationDecl *tmpl);
 
 private:
 	Document &m_document;
-	Enum m_enum;
+	std::string m_enumName;
 };
 
 #endif // ENUM_MATCH_HANDLER_HPP

--- a/clang/include/structures.hpp
+++ b/clang/include/structures.hpp
@@ -160,7 +160,8 @@ struct Enum {
 	std::string name;
 	std::string type;
 	bool isFlags = false;
-	std::vector<std::pair<std::string, int64_t>> values;
+	bool isAnonymous = false;
+	JsonMap<std::string, int64_t> values;
 };
 
 JsonStream &operator<<(JsonStream &s, const Enum &value);

--- a/clang/src/structures.cpp
+++ b/clang/src/structures.cpp
@@ -207,21 +207,14 @@ JsonStream &operator<<(JsonStream &s, const Class &value) {
 
 JsonStream &operator<<(JsonStream &s, const Enum &value) {
 	auto c = JsonStream::Comma;
-	s << JsonStream::ObjectBegin
+	return s
+		<< JsonStream::ObjectBegin
 		<< std::make_pair("name", value.name) << c
 		<< std::make_pair("type", value.type) << c
 		<< std::make_pair("isFlags", value.isFlags) << c
-		<< "values" << JsonStream::Separator << JsonStream::ObjectBegin;
-
-	bool first = true;
-	for (const std::pair<std::string, int64_t> &elem : value.values) {
-		if (!first) s << c;
-		s << std::make_pair(elem.first, elem.second);
-		first = false;
-	}
-
-	s << JsonStream::ObjectEnd << JsonStream::ObjectEnd;
-	return s;
+		<< std::make_pair("isAnonymous", value.isAnonymous) << c
+		<< std::make_pair("values", value.values)
+		<< JsonStream::ObjectEnd;
 }
 
 JsonStream &operator<<(JsonStream &s, const Macro &value) {

--- a/spec/integration/enums.cpp
+++ b/spec/integration/enums.cpp
@@ -1,0 +1,35 @@
+#include <cstdint>
+
+enum TopLevel {
+  A,
+  B = A,
+  C = -1,
+};
+
+namespace NS1 {
+  enum InnerEnum { X };
+
+  namespace NS2 {
+    enum InnerEnum2 { X };
+  }
+}
+
+enum U8Enum : uint8_t {
+  D,
+  E = (uint8_t)-1,
+};
+
+
+
+template <typename T>
+class QFlags { };
+
+enum FlagEnum {
+  None = 0x00,
+  P = 0x01,
+  Q = 0x04,
+  R = 0x0C,
+};
+
+template class QFlags<FlagEnum>;
+typedef QFlags<FlagEnum> Flags;

--- a/spec/integration/enums.cpp
+++ b/spec/integration/enums.cpp
@@ -39,3 +39,7 @@ typedef QFlags<FlagEnum> Flags;
 struct Nested {
   enum { X = 10, Y = 20 };
 };
+
+struct Renamed {
+  enum { Z = 30 };
+};

--- a/spec/integration/enums.cpp
+++ b/spec/integration/enums.cpp
@@ -2,8 +2,8 @@
 
 enum TopLevel {
   A,
-  B = A,
-  C = -1,
+  b = A,
+  c_c = -1,
 };
 
 namespace NS1 {

--- a/spec/integration/enums.cpp
+++ b/spec/integration/enums.cpp
@@ -33,3 +33,9 @@ enum FlagEnum {
 
 template class QFlags<FlagEnum>;
 typedef QFlags<FlagEnum> Flags;
+
+
+
+struct Nested {
+  enum { X = 10, Y = 20 };
+};

--- a/spec/integration/enums.yml
+++ b/spec/integration/enums.yml
@@ -2,6 +2,9 @@
 
 # Uses the default processor pipeline.
 
+classes:
+  Nested: Nested
+
 enums:
   TopLevel: TopLevel
   U8Enum: U8Enum

--- a/spec/integration/enums.yml
+++ b/spec/integration/enums.yml
@@ -1,0 +1,10 @@
+<<: spec_base.yml
+
+# Uses the default processor pipeline.
+
+enums:
+  TopLevel: TopLevel
+  U8Enum: U8Enum
+  NS1::InnerEnum: NS1::InnerEnum
+  NS1::NS2::InnerEnum2: NS1::NS2::InnerEnum2
+  Flags: Flags

--- a/spec/integration/enums.yml
+++ b/spec/integration/enums.yml
@@ -4,6 +4,7 @@
 
 classes:
   Nested: Nested
+  Renamed: MyRenamed
 
 enums:
   TopLevel: TopLevel

--- a/spec/integration/enums_spec.cr
+++ b/spec/integration/enums_spec.cr
@@ -44,6 +44,9 @@ describe "enumeration types functionality" do
           Test::Nested::X.should be_a(UInt32)
           Test::Nested::Y.should eq(20)
           Test::Nested::Y.should be_a(UInt32)
+
+          Test::MyRenamed::Z.should eq(30)
+          {{ Test.has_constant?("Renamed") }}.should be_false
         end
       end
     end

--- a/spec/integration/enums_spec.cr
+++ b/spec/integration/enums_spec.cr
@@ -11,7 +11,7 @@ describe "enumeration types functionality" do
 
       context "core functionality" do
         it "supports top-level enums" do
-          Test::TopLevel.names.should eq(%w{A B C})
+          Test::TopLevel.names.should eq(%w{A B CC})
           Test::TopLevel.values.map(&.to_i).should eq([0, 0, -1])
           enum_type(Test::TopLevel).should eq(Int32)
         end

--- a/spec/integration/enums_spec.cr
+++ b/spec/integration/enums_spec.cr
@@ -1,0 +1,42 @@
+require "./spec_helper"
+
+describe "enumeration types functionality" do
+  it "works" do
+    build_and_run("enums") do
+      # See also ../spec/bindgen/processor/enums_spec.cr
+
+      private def enum_type(enumeration : T.class) forall T
+        typeof(T.values.first.value)
+      end
+
+      context "core functionality" do
+        it "supports top-level enums" do
+          Test::TopLevel.names.should eq(%w{A B C})
+          Test::TopLevel.values.map(&.to_i).should eq([0, 0, -1])
+          enum_type(Test::TopLevel).should eq(Int32)
+        end
+
+        it "supports namespaced enums" do
+          Test::NS1::InnerEnum::X.value.should eq(0)
+          Test::NS1::NS2::InnerEnum2::X.value.should eq(0)
+        end
+
+        it "supports enums with explicit types" do
+          Test::U8Enum.names.should eq(%w{D E})
+          Test::U8Enum.values.map(&.to_i).should eq([0, 255])
+          enum_type(Test::U8Enum).should eq(UInt8)
+        end
+      end
+
+      context "Qt-specific functionality" do
+        it "recognizes `QFlags<T>`" do
+          {{ Test::Flags.has_attribute?("Flags") }}.should be_true
+          Test::Flags.names.should eq(%w{P Q R})
+          Test::Flags.values.map(&.to_i).should eq([1, 4, 12])
+          Test::Flags::None.value.should eq(0)
+          Test::Flags::All.value.should eq(13)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/enums_spec.cr
+++ b/spec/integration/enums_spec.cr
@@ -37,6 +37,15 @@ describe "enumeration types functionality" do
           Test::Flags::All.value.should eq(13)
         end
       end
+
+      context "nested anonymous enums" do
+        it "writes enum values to the enclosing scope as constants" do
+          Test::Nested::X.should eq(10)
+          Test::Nested::X.should be_a(UInt32)
+          Test::Nested::Y.should eq(20)
+          Test::Nested::Y.should be_a(UInt32)
+        end
+      end
     end
   end
 end

--- a/src/bindgen/parser/enum.cr
+++ b/src/bindgen/parser/enum.cr
@@ -17,10 +17,14 @@ module Bindgen
       @[JSON::Field(key: "isFlags")]
       getter? flags : Bool
 
+      # Is this enumeration anonymous?
+      @[JSON::Field(key: "isAnonymous")]
+      getter? anonymous : Bool
+
       # Enum fields
       getter values : Hash(String, Int64)
 
-      def initialize(@name, @values, @type = "unsigned int", @flags = false)
+      def initialize(@name, @values, @type = "unsigned int", @flags = false, @anonymous = false)
       end
 
       def_equals_and_hash @name, @type, @flags, @values

--- a/src/bindgen/processor/enums.cr
+++ b/src/bindgen/processor/enums.cr
@@ -7,7 +7,6 @@ module Bindgen
           if enumeration.anonymous?
             config = Configuration::Enum.new(
               destination: enumeration.name,
-              camelcase: false,
             )
           else
             config = @config.enums[name]
@@ -24,9 +23,10 @@ module Bindgen
         if origin.anonymous?
           # Re-parent the anonumous enum if the enclosing class is wrapped.
           path = Graph::Path.from(config.destination)
-          parent = path.parent.to_s
-          if wrapper_name = @db[parent]?.try(&.wrapper_type)
-            path = Graph::Path.from(wrapper_name, path.last_part)
+          if parent = @db[path.parent.to_s]?
+            if parent.generate_wrapper? && (wrapper_name = parent.wrapper_type)
+              path = Graph::Path.from(wrapper_name, path.last_part)
+            end
           end
 
           emit_enum(origin, path, root)

--- a/src/bindgen/processor/enums.cr
+++ b/src/bindgen/processor/enums.cr
@@ -22,7 +22,14 @@ module Bindgen
         origin = reconfigure_enum(config, enumeration)
 
         if origin.anonymous?
-          emit_enum(origin, config.destination, root)
+          # Re-parent the anonumous enum if the enclosing class is wrapped.
+          path = Graph::Path.from(config.destination)
+          parent = path.parent.to_s
+          if wrapper_name = @db[parent]?.try(&.wrapper_type)
+            path = Graph::Path.from(wrapper_name, path.last_part)
+          end
+
+          emit_enum(origin, path, root)
         else
           builder = Graph::Builder.new(@db)
           builder.build_enum(origin, config.destination, root)


### PR DESCRIPTION
This PR adds support for nested constants defined in the form of anonymous enums:

```cpp
struct A {
  enum { X, Y, Z };
};
```

```crystal
class A
  X = 0u32
  Y = 1u32
  Z = 2u32
end
```

Such constructs are sometimes seen in C++ code to define compile-time constants, instead of `static const`. Qt uses it for [`QGraphicsItem::type()`](https://doc.qt.io/qt-5/qgraphicsitem.html#anonymous-enum).

This PR does not address the use of anonymous enumerators in instance variables.