### PR TITLE
Generate property methods / constants for static data members

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The following rules are automatically applied to all bindings:
 |  +- Member methods                               | **YES** |
 |  +- Static methods                               | **YES** |
 |  +- Getters and setters for instance variables   | **YES** |
+|  +- Getters and setters for static variables     | **YES** |
 |  +- Constructors                                 | **YES** |
 |  +- Overloaded operators                         |   TBD   |
 |  +- Conversion functions                         |   TBD   |
@@ -406,7 +407,7 @@ return instances to the (otherwise) abstract class.
 * **Run after**: No specific dependency
 * **Run before**: No specific dependency
 
-Generates getter and setter methods for instance members.
+Generates getter and setter methods for static and instance members.
 
 ## `InstantiateContainers`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -242,9 +242,9 @@ inherits from `MyFoo` and overrides `#bar`, the overriding method may refer to
 
 ### §2.4 Instance properties
 
-Property methods can be generated for an instance variable in a Crystal wrapper
-corresponding to a C++ `class`, `struct`, or `union`, if all of the following
-criteria are met:
+Property methods can be generated for any static or instance variable in a
+Crystal wrapper corresponding to a C++ `class`, `struct`, or `union`, if all of
+the following criteria are met:
 
 * The member's visibility is `public` or `protected` (the latter is mapped to
   `private` in Crystal)
@@ -254,9 +254,8 @@ criteria are met:
 * The member is not inside a nested anonymous type that names another member
   (this is supported by §3.2.2)
 
-The getter is always defined for every instance variable, but the setter is
-omitted if the instance variable was defined as a `const` member.  Property
-methods are underscored.
+The getter is always defined for every member, but the setter is omitted if the
+member was defined as a `const` member.  Property methods are underscored.
 
 ```cpp
 struct Point {
@@ -280,10 +279,9 @@ end
 
 ### §2.4.1 Class type properties
 
-If an instance variable is a value of another wrapped type, by default the
-getter allocates a copy of the variable in C/C++ (using the C++ type's copy
-constructor), so it is safe to modify the returned object without altering the
-original instance.
+If a data member is a value of another wrapped type, the getter allocates a copy
+of the variable in C/C++ (using the C++ type's copy constructor), so it is safe
+to modify the returned object without altering the original value.
 
 ```cpp
 struct Line {
@@ -306,10 +304,10 @@ end
 
 ### §2.4.2 Pointer properties
 
-If an instance variable is a pointer to a wrapped type, instances of the wrapped
-type can be passed directly without forming any pointers.  These properties may
-additionally be configured as nilable, in which case they may accept and return
-`nil` as well, corresponding to C++'s `nullptr`.
+If a data member is a pointer to a wrapped type, instances of the wrapped type
+can be passed to C++ directly without having to construct any pointers in
+Crystal.  These properties may additionally be configured as nilable, in which
+case they may accept and return `nil` as well, corresponding to C++'s `nullptr`.
 
 ```cpp
 struct LinkedList {
@@ -372,11 +370,32 @@ struct Props {
 ```crystal
 class Props
   def foo : Int32 end
-  def foo=(foo : Int32) end
+  def foo=(foo : Int32) : Void end
   def bar : Char end
-  def bar=(bar : Char) end
+  def bar=(bar : Char) : Void end
   def baz : Char end
-  def baz=(baz : Char) end
+  def baz=(baz : Char) : Void end
+end
+```
+
+### §2.4.4 Static data members
+
+Static variables have the wrapper class itself as the receiver.  The names for
+constant member getters are still underscored, and their initializers are NOT
+copied to the Crystal wrappers.
+
+```cpp
+struct Application {
+  static Application *instance;
+  static const int VERSION = 103;
+};
+```
+
+```crystal
+class Application
+  def self.instance : Application end
+  def self.instance=(instance : Application) : Void end
+  def self.version : Int32 end
 end
 ```
 
@@ -415,6 +434,7 @@ generated methods may use custom markers to distinguish them.
 
 * Member methods don't have a marker
 * Static methods use `STATIC`
+* Property methods use either `GETTER` or `SETTER` (see §2.4)
 * Constructors use `CONSTRUCT`
 * Destructors use `DESTRUCT`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -253,9 +253,11 @@ the following criteria are met:
 * The type's `instance_variable` settings do not reject the member
 * The member is not inside a nested anonymous type that names another member
   (this is supported by §3.2.2)
+* The member does not satisfy the requirements for wrapped static constants (see
+  §2.4.5)
+* The method is not a setter for a `const` member
 
-The getter is always defined for every member, but the setter is omitted if the
-member was defined as a `const` member.  Property methods are underscored.
+The names of property methods are underscored according to the member name.
 
 ```cpp
 struct Point {
@@ -387,7 +389,7 @@ copied to the Crystal wrappers.
 ```cpp
 struct Application {
   static Application *instance;
-  static const int VERSION = 103;
+  static const int VERSION; // not defined
 };
 ```
 
@@ -396,6 +398,29 @@ class Application
   def self.instance : Application end
   def self.instance=(instance : Application) : Void end
   def self.version : Int32 end
+end
+```
+
+### §2.4.5 Static constants
+
+If a static variable additionally satisfies the following conditions, a wrapped
+constant will be generated instead of a getter method:
+
+* The member is `const` or `constexpr`
+* The member's initializer is available in the parsed C++ sources
+* The member is an integral, floating-point, or boolean value
+
+```cpp
+struct Application {
+  static const int VERSION = 103;
+  static constexpr double epsilon = 0.000001;
+};
+```
+
+```crystal
+class Application
+  VERSION = 103
+  EPSILON = 1.0e-6
 end
 ```
 

--- a/TEMPLATE.yml
+++ b/TEMPLATE.yml
@@ -36,7 +36,7 @@ processors:
   - copy_structs # Copy structures as marked
   - macros # Support for macro mapping
   - functions # Add non-class functions
-  - instance_properties # Add property methods for public instance members
+  - instance_properties # Add property methods for static and instance members
   - filter_methods # Throw out filtered methods
   - extern_c # Directly bind to pure C functions
   - instantiate_containers # Actually instantiate containers
@@ -433,26 +433,26 @@ types:
     # Defaults to `false`.
     copy_structure: true | false
 
-    # Whether to generate property methods for instance variables.  It may take
-    # a boolean or a hash:
+    # Whether to generate property methods for static and instance variables.
+    # It accepts a boolean or a hash:
     # * `true`: Generate all methods with their default settings.
     # * `false`: Disable all methods.
-    # * Hash: Each key is a regex pattern matching the names of the instance
-    #   variables, and the corresponding value controls the behaviour of the
-    #   matched variables.
+    # * Hash: Each key is a regex pattern matching the names of the data
+    #   members, and the corresponding value controls the behaviour of the
+    #   matched members.
     # Defaults to `true`.  `copy_structure: true` will suppress the generation
     # of property methods regardless of this setting.
     instance_variables:
       "^m_i(.*)$":
-        # Do not generate the getter(s) and setter(s) for the matched variables.
+        # Do not generate the getter(s) and setter(s) for the matched members.
         # Defaults to `false`.
         ignore: true | false
         # Optional: renames the property method(s).  Regex backreferences are
         # supported.  Underscore transformation is applied after renaming.
         # By default no renaming is applied.
         rename: "\\1"
-        # Marks the instance variable(s) as nilable, allowing the property
-        # methods to use `nil`.  Only applied to pointer variables.
+        # Marks the data member(s) as nilable, allowing the property methods to
+        # use `nil`.  Only applied to members of pointer types.
         # Defaults to `false`.
         nilable: true | false
 

--- a/clang/include/record_match_handler.hpp
+++ b/clang/include/record_match_handler.hpp
@@ -12,7 +12,9 @@ private:
 
 	bool runOnRecord(Class &klass, const clang::CXXRecordDecl *record);
 
-	bool runOnField(Field &f, Class &klass, const clang::FieldDecl *field);
+	bool runOnField(Field &f, const clang::FieldDecl *field);
+
+	bool runOnStaticField(Field &f, const clang::VarDecl *var);
 
 	bool checkAccessSpecForSignal(clang::AccessSpecDecl *spec);
 

--- a/clang/include/structures.hpp
+++ b/clang/include/structures.hpp
@@ -133,6 +133,7 @@ JsonStream &operator<<(JsonStream &s, const BaseClass &value);
 struct Field : public Type {
 	clang::AccessSpecifier access;
 	std::string name;
+	bool isStatic = false;
 	int bitField = -1;
 };
 

--- a/clang/include/structures.hpp
+++ b/clang/include/structures.hpp
@@ -39,7 +39,6 @@ struct LiteralData {
 		UIntKind,
 		DoubleKind,
 		StringKind,
-		TerminalKind,
 	};
 
 	Kind kind;
@@ -49,7 +48,6 @@ struct LiteralData {
 		int64_t int_value;
 		uint64_t uint_value;
 		double double_value;
-		JsonStream::Terminal terminal_value;
 		std::string *string_value;
 	} container;
 
@@ -68,11 +66,11 @@ struct LiteralData {
 
 	// Setters
 
+	void clear();
 	void set(bool v);
 	void set(int64_t v);
 	void set(uint64_t v);
 	void set(double v);
-	void set(JsonStream::Terminal v);
 	void set(const std::string &v);
 };
 
@@ -134,6 +132,8 @@ struct Field : public Type {
 	clang::AccessSpecifier access;
 	std::string name;
 	bool isStatic = false;
+	bool hasDefault = false; // Does this field have a default value?
+	LiteralData value; // Default value of the field
 	int bitField = -1;
 };
 

--- a/clang/src/structures.cpp
+++ b/clang/src/structures.cpp
@@ -166,7 +166,8 @@ JsonStream &operator<<(JsonStream &s, const Field &value) {
 	s << JsonStream::ObjectBegin;
 	writeTypeJson(s, value) << c;
 	s << std::make_pair("name", value.name) << c
-		<< std::make_pair("access", value.access) << c;
+		<< std::make_pair("access", value.access) << c
+		<< std::make_pair("isStatic", value.isStatic) << c;
 
 	if (value.bitField > 0)
 		s << std::make_pair("bitField", value.name);

--- a/clang/src/structures.cpp
+++ b/clang/src/structures.cpp
@@ -51,11 +51,11 @@ bool LiteralData::hasValue() const {
 	return (this->kind != None);
 }
 
+void LiteralData::clear() { this->kind = None; }
 void LiteralData::set(bool v) { this->kind = BoolKind; this->container.bool_value = v; }
 void LiteralData::set(int64_t v) { this->kind = IntKind; this->container.int_value = v; }
 void LiteralData::set(uint64_t v) { this->kind = UIntKind; this->container.uint_value = v; }
 void LiteralData::set(double v) { this->kind = DoubleKind; this->container.double_value = v; }
-void LiteralData::set(JsonStream::Terminal v) { this->kind = TerminalKind; this->container.terminal_value = v; }
 void LiteralData::set(const std::string &v) {
 	this->kind = StringKind;
 	this->container.string_value = new std::string(v);
@@ -75,9 +75,6 @@ JsonStream &operator<<(JsonStream &s, const LiteralData &value) {
 		break;
 	case LiteralData::DoubleKind:
 		s << value.container.double_value;
-		break;
-	case LiteralData::TerminalKind:
-		s << value.container.terminal_value;
 		break;
 	case LiteralData::StringKind:
 		s << *value.container.string_value;
@@ -167,7 +164,12 @@ JsonStream &operator<<(JsonStream &s, const Field &value) {
 	writeTypeJson(s, value) << c;
 	s << std::make_pair("name", value.name) << c
 		<< std::make_pair("access", value.access) << c
-		<< std::make_pair("isStatic", value.isStatic) << c;
+		<< std::make_pair("isStatic", value.isStatic) << c
+		<< std::make_pair("hasDefault", value.hasDefault) << c;
+
+	if (value.hasDefault && value.value.hasValue()) {
+		s << std::make_pair("value", value.value) << c;
+	}
 
 	if (value.bitField > 0)
 		s << std::make_pair("bitField", value.name);

--- a/spec/integration/copy_structs.cpp
+++ b/spec/integration/copy_structs.cpp
@@ -4,6 +4,8 @@ struct Point {
   Point(int x, int y) : x(x), y(y) { }
 
   int x, y;
+
+  static const int DIMENSIONS = 2;
 };
 
 struct Line {

--- a/spec/integration/copy_structs.cpp
+++ b/spec/integration/copy_structs.cpp
@@ -116,6 +116,8 @@ public:
   Point *position_ptr = new Point(12, 34);
   Point position_val {13, 35};
 
+  static Point corner;
+
 protected:
   int x_prot;
   const int y_prot;
@@ -124,6 +126,8 @@ private:
   int x_priv;
   const int y_priv;
 };
+
+Point Props::corner = Point(800, 600);
 
 class NestedProtected {
 protected:

--- a/spec/integration/copy_structs.cpp
+++ b/spec/integration/copy_structs.cpp
@@ -117,6 +117,9 @@ public:
   Point position_val {13, 35};
 
   static Point corner;
+  static const Point origin;
+  static constexpr float c_f32 = 1.2;
+  static const bool c_b = true;
 
 protected:
   int x_prot;
@@ -128,6 +131,7 @@ private:
 };
 
 Point Props::corner = Point(800, 600);
+const Point Props::origin = Point(0, 0);
 
 class NestedProtected {
 protected:

--- a/spec/integration/copy_structs_spec.cr
+++ b/spec/integration/copy_structs_spec.cr
@@ -27,7 +27,7 @@ describe "copied structure functionality" do
       context "core functionality" do
         it "supports structs" do
           subject = Test::Binding::Point.new
-          instance_var_names(subject).should eq(%w{x y})
+          instance_var_names(subject).should eq(%w{x y}) # ignores `dimensions`
           subject.x.should be_a(Int32)
           subject.y.should be_a(Int32)
         end

--- a/spec/integration/instance_properties_spec.cr
+++ b/spec/integration/instance_properties_spec.cr
@@ -63,6 +63,15 @@ describe "C++ instance properties" do
           position.x.should eq(13)
           position.y.should eq(35)
         end
+
+        it "supports static members" do
+          Test::Point.dimensions.should eq(2)
+
+          position = Test::Props.corner
+          position.should be_a(Test::Point)
+          position.x.should eq(800)
+          position.y.should eq(600)
+        end
       end
 
       context "setter methods" do
@@ -97,6 +106,8 @@ describe "C++ instance properties" do
           methods.includes?("y_pub=").should be_false
           methods.includes?("y_prot=").should be_false
           methods.includes?("y_priv=").should be_false
+
+          {{ Test::Props.class.has_method?("dimensions=") }}.should be_false
         end
 
         it "supports pointer members" do
@@ -113,6 +124,14 @@ describe "C++ instance properties" do
           got = props.position_val
           got.x.should eq(60)
           got.y.should eq(61)
+        end
+
+        it "supports static members" do
+          Test::Props.corner = Test::Point.new(1024, 768)
+          got = Test::Props.corner
+          got.should be_a(Test::Point)
+          got.x.should eq(1024)
+          got.y.should eq(768)
         end
       end
 

--- a/spec/integration/instance_properties_spec.cr
+++ b/spec/integration/instance_properties_spec.cr
@@ -65,12 +65,32 @@ describe "C++ instance properties" do
         end
 
         it "supports static members" do
-          Test::Point.dimensions.should eq(2)
-
           position = Test::Props.corner
           position.should be_a(Test::Point)
           position.x.should eq(800)
           position.y.should eq(600)
+
+          position = Test::Props.origin
+          position.should be_a(Test::Point)
+          position.x.should eq(0)
+          position.y.should eq(0)
+        end
+
+        it "ignores wrapped constants" do
+          {{ Test::Point.class.has_method?("dimensions") }}.should be_false
+          {{ Test::Props.class.has_method?("c_f32") }}.should be_false
+          {{ Test::Props.class.has_method?("c_b") }}.should be_false
+        end
+      end
+
+      context "static const members" do
+        it "supports static constants with arithmetic initializers" do
+          Test::Point::DIMENSIONS.should eq(2)
+          Test::Point::DIMENSIONS.should be_a(Int32)
+          Test::Props::C_F32.should eq(1.2_f32)
+          Test::Props::C_F32.should be_a(Float32)
+          Test::Props::C_B.should eq(true)
+          Test::Props::C_B.should be_a(Bool)
         end
       end
 
@@ -106,8 +126,6 @@ describe "C++ instance properties" do
           methods.includes?("y_pub=").should be_false
           methods.includes?("y_prot=").should be_false
           methods.includes?("y_priv=").should be_false
-
-          {{ Test::Props.class.has_method?("dimensions=") }}.should be_false
         end
 
         it "supports pointer members" do
@@ -132,6 +150,13 @@ describe "C++ instance properties" do
           got.should be_a(Test::Point)
           got.x.should eq(1024)
           got.y.should eq(768)
+        end
+
+        it "is ignored for static const members" do
+          {{ Test::Point.class.has_method?("dimensions=") }}.should be_false
+          {{ Test::Props.class.has_method?("origin=") }}.should be_false
+          {{ Test::Props.class.has_method?("c_f32=") }}.should be_false
+          {{ Test::Props.class.has_method?("c_b=") }}.should be_false
         end
       end
 

--- a/src/bindgen/call_builder/crystal_abstract_def.cr
+++ b/src/bindgen/call_builder/crystal_abstract_def.cr
@@ -28,7 +28,7 @@ module Bindgen
             name: call.name,
             arguments: call.arguments,
             result: call.result,
-            static: call.origin.static_method?,
+            static: call.origin.static?,
             abstract: true,
             protected: call.origin.protected?,
           )

--- a/src/bindgen/call_builder/crystal_wrapper.cr
+++ b/src/bindgen/call_builder/crystal_wrapper.cr
@@ -73,7 +73,7 @@ module Bindgen
             name: call.name,
             arguments: arguments,
             result: result,
-            static: call.origin.static_method?,
+            static: call.origin.static?,
             abstract: call.origin.pure?,
             protected: call.origin.protected?,
             private: call.origin.private?,

--- a/src/bindgen/cpp/method_name.cr
+++ b/src/bindgen/cpp/method_name.cr
@@ -39,7 +39,7 @@ module Bindgen
           else
             "#{self_var}->#{method.name}"
           end
-        when .static_method?
+        when .static?
           qualified(method)
         else
           raise "BUG: Missing case for method type #{method.type.inspect}"

--- a/src/bindgen/crystal/format.cr
+++ b/src/bindgen/crystal/format.cr
@@ -76,8 +76,10 @@ module Bindgen
       # valid a Crystal literal, and can be directly written.
       def number_literal(type_name, value) : String?
         if suffix = number_literal_suffix(type_name)
-          if floating_type?(type_name)
-            value = value.to_f
+          if type_name == "Float32"
+            value = value.to_f32
+          elsif type_name == "Float64"
+            value = value.to_f64
           elsif !value.is_a?(Int)
             value = value.to_i
           end
@@ -131,11 +133,6 @@ module Bindgen
         else # All names found: Build a nice `.flags` list
           ".flags(#{names.join(", ")})"
         end
-      end
-
-      # Returns `true` if *type_name* is a Crystal floating-type.
-      def floating_type?(type_name) : Bool
-        {"Float32", "Float64"}.includes?(type_name)
       end
 
       # Returns the literal-suffix for Crystal code, to signify a literal

--- a/src/bindgen/crystal/type.cr
+++ b/src/bindgen/crystal/type.cr
@@ -32,7 +32,7 @@ module Bindgen
           return value.to_s # Special case for `(const) char *`
         end
 
-        target_type = @db.try_or(type, type.base_name, &.binding_type)
+        target_type = @db.try_or(type, type.base_name, &.wrapper_type)
         case resolve_long(target_type)
         when "UInt8"   then as_number(value, &.to_u8)
         when "UInt16"  then as_number(value, &.to_u16)

--- a/src/bindgen/graph/method.cr
+++ b/src/bindgen/graph/method.cr
@@ -39,7 +39,7 @@ module Bindgen
       # Returns a dot (`.`) if the origin method is static.  Returns a number
       # sign (`#`) otherwise.
       def crystal_prefix : String
-        if @origin.static_method?
+        if @origin.static?
           "."
         else
           "#"

--- a/src/bindgen/graph/struct.cr
+++ b/src/bindgen/graph/struct.cr
@@ -2,13 +2,13 @@ module Bindgen
   module Graph
     # A `struct` in Crystal (`lib` or not), or a plain `struct` in C++.
     #
-    # A structure can host both raw variable fields (C-style) and other methods
-    # at once.
+    # A structure can host both raw non-static variable fields (C-style) and
+    # other methods at once.
     class Struct < Container
       # Used to signal the `Generator::Cpp` to generate a `using BASE::BASE;`.
       INHERIT_CONSTRUCTORS_TAG = "INHERIT_CONSTRUCTORS_TAG"
 
-      # Fields in this structure.
+      # Non-static fields in this structure.
       getter fields : Hash(String, Call::Result)
 
       # Name of the base-class, if any.  This is mainly useful for C++ to

--- a/src/bindgen/parser/argument.cr
+++ b/src/bindgen/parser/argument.cr
@@ -17,7 +17,7 @@ module Bindgen
       # Name of this argument.
       getter name : String
 
-      # Default value for this argument, if any.
+      # Default value for this argument, if an initializer literal is found.
       @[JSON::Field(converter: Bindgen::Parser::ValueConverter)]
       getter value : DefaultValueTypes?
 

--- a/src/bindgen/parser/class.cr
+++ b/src/bindgen/parser/class.cr
@@ -45,7 +45,7 @@ module Bindgen
       # Direct bases of the class.
       getter bases : Array(BaseClass)
 
-      # Data members defined in the class.
+      # Data members defined in the class, both static and non-static.
       getter fields : Array(Field)
 
       # Methods defined in the class.

--- a/src/bindgen/parser/field.cr
+++ b/src/bindgen/parser/field.cr
@@ -10,6 +10,10 @@ module Bindgen
       # Name of the field.
       getter name : String
 
+      # Is this field a static data member?
+      @[JSON::Field(key: "isStatic")]
+      getter? static : Bool
+
       # The size of this field, if it is a bitfield.
       @[JSON::Field(key: "bitField")]
       getter! bit_field : Int32

--- a/src/bindgen/parser/field.cr
+++ b/src/bindgen/parser/field.cr
@@ -18,6 +18,14 @@ module Bindgen
       @[JSON::Field(key: "bitField")]
       getter! bit_field : Int32
 
+      # Does this field have a default value?
+      @[JSON::Field(key: "hasDefault")]
+      getter? has_default : Bool
+
+      # Default value for this field, if an initializer literal is found.
+      @[JSON::Field(converter: Bindgen::Parser::ValueConverter)]
+      getter value : DefaultValueTypes?
+
       delegate public?, private?, protected?, to: @access
 
       # Suitable name for Crystal code

--- a/src/bindgen/processor/inheritance.cr
+++ b/src/bindgen/processor/inheritance.cr
@@ -201,7 +201,7 @@ module Bindgen
           name: "#{klass.name}Impl",
           byte_size: klass.byte_size,
           bases: [base],
-          fields: klass.fields.dup,
+          fields: klass.fields.select { |f| !f.static? },
           methods: klass.methods.map { |m| unabstract_method(m) },
         )
       end

--- a/src/bindgen/processor/sanity_check.cr
+++ b/src/bindgen/processor/sanity_check.cr
@@ -131,7 +131,7 @@ module Bindgen
           overloads.each_combination(2, reuse: true) do |perm|
             method1, call1 = perm[0]
             method2, call2 = perm[1]
-            if method1.origin.static_method? == method2.origin.static_method?
+            if method1.origin.static? == method2.origin.static?
               if ambiguous_signatures?(call1.arguments, call2.arguments)
                 add_error(method1, "Ambiguous call")
                 add_error(method2, "Ambiguous call")

--- a/src/bindgen/type_database.cr
+++ b/src/bindgen/type_database.cr
@@ -98,8 +98,8 @@ module Bindgen
       # virtual methods.
       property? sub_class = true
 
-      # If the structure (as in, its fields) shall be tried to replicated in
-      # Crystal.  Implies `instance_variables: false`.
+      # If the structure (as in, its non-static fields) shall be tried to
+      # replicated in Crystal.  Implies `instance_variables: false`.
       # This doesn't support inheritance!
       property? copy_structure = false
 


### PR DESCRIPTION
Generates getters and setters for static variables, just like instance variables. Considerable portions of the changes are just documentation changes to reflect that both static and non-static data members are supported.

```cpp
struct Application {
  static Application *instance;
  static const int VERSION = 103;
};
Application *Application::instance = /* ... */;
```

produces:

```cpp
extern "C" Application * bg_Application_instance_STATIC_GETTER_() {
  return Application::instance;
}

extern "C" void bg_Application_instance_STATIC_SETTER_Application_X(Application * instance) {
  Application::instance = instance;
}

extern "C" const int bg_Application_VERSION_STATIC_GETTER_() {
  return Application::VERSION;
}
```

```crystal
module Test
  lib Binding
    alias Application = Void
    fun bg_Application_instance_STATIC_GETTER_() : Application*
    fun bg_Application_instance_STATIC_SETTER_Application_X(instance : Application*) : Void
    fun bg_Application_VERSION_STATIC_GETTER_() : Int32
  end

  class Application
    def self.instance() : Application
      Application.new(unwrap: Binding.bg_Application_instance_STATIC_GETTER_())
    end
    
    def self.instance=(instance : Application) : Void
      Binding.bg_Application_instance_STATIC_SETTER_Application_X(instance)
    end
    
    def self.version() : Int32
      Binding.bg_Application_VERSION_STATIC_GETTER_()
    end
  end
end
```

This PR does not map constant members to Crystal constants yet, because in general the constant itself may be altered in Crystal if it is a wrapper (which inherits from `Reference`, and only prevents assignments):

```cpp
struct Point {
    int x, y;
    static const Point ORIGIN;
};
const Point Point::ORIGIN = {0, 0};
```

```crystal
class Point
  ORIGIN = Binding.bg_Point_ORIGIN_STATIC_GETTER_()
  # ORIGIN is actually a *copy* of the C++ constant on the heap
end

Point::ORIGIN.x = 4 # should not be allowed
```

Interestingly, Qt uses almost no static members, and the only differences after this PR are `QObject::staticMetaObject`. (Integral constants used anonymous enums a bit.)