### PR TITLE
Support most overloaded member operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following rules are automatically applied to all bindings:
 |  +- Getters and setters for instance variables   | **YES** |
 |  +- Getters and setters for static variables     | **YES** |
 |  +- Constructors                                 | **YES** |
-|  +- Overloaded operators                         |   TBD   |
+|  +- Overloaded operators                         | Partial |
 |  +- Conversion functions                         |   TBD   |
 | Mapping C/C++ global functions                   |         |
 |  +- Mapping global functions                     | **YES** |
@@ -437,6 +437,14 @@ function-like macros are silently skipped.
 // Not mapped:
 #define SOME_FUNCTION(x) (x + 1)
 ```
+
+## `Operators`
+
+* **Kind**: Refining
+* **Run after**: No specific dependency
+* **Run before**: No specific dependency
+
+Performs special handling for operator methods.
 
 ## `Qt`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -90,7 +90,7 @@ considered.
 |`()(T...)`|`call(*T)`|
 
 The following C++ operators are ignored: `=(T)`, `<=>(T)`, `&()`, `->()`,
-`->*(T)`, `,(T)`.
+`->*(T)`, `,(T)`, all conversion operators.
 
 The following Crystal operators are overloadable, but unused by Bindgen:
 `&+`, `&-`, `&+(T)`, `&-(T)`, `&*(T)`, `&**(T)`, `//(T)`, `===(T)`, `<=>(T)`,

--- a/SPEC.md
+++ b/SPEC.md
@@ -52,6 +52,50 @@ A setter is a method which:
 If these rules are fulfilled, then the `set` prefix is removed, and a Crystal
 writer method is created: `setWindowTitle() -> #window_title=`
 
+#### §2.1.4 Overloaded operators
+
+An overloaded operator is a method which:
+
+1. Appears inside the class definition
+2. Is not a `friend` declaration
+3. Corresponds to a Crystal method in the table below
+
+Both `T` and the return type can be anything; const-ness of the method is not
+considered.
+
+|C++ operator|Crystal method|
+|-|-|
+|`+()`, `-()`, `~()`|`operator` dropped|
+|`++()`|`succ!`|
+|`++(int)`|`post_succ!`|
+|`--()`|`pred!`|
+|`--(int)`|`post_pred!`|
+|`!()`|`not`|
+|`*()`|`deref`|
+|`==(T)`, `!=(T)`, `<(T)`, `>(T)`, `<=(T)`, `>=(T)`|`operator` dropped|
+|`+(T)`, `-(T)`, `*(T)`, `/(T)`, `%(T)`, `&(T)`, `|(T)`, `^(T)`, `<<(T)`, `>>(T)`|`operator` dropped|
+|`+=(T)`|`add!(T)`|
+|`-=(T)`|`sub!(T)`|
+|`*=(T)`|`mul!(T)`|
+|`/=(T)`|`div!(T)`|
+|`%=(T)`|`mod!(T)`|
+|`&=(T)`|`bit_and!(T)`|
+|`|=(T)`|`bit_or!(T)`|
+|`^=(T)`|`bit_xor!(T)`|
+|`<<=(T)`|`lshift!(T)`|
+|`>>=(T)`|`rshift!(T)`|
+|`&&(T)`|`and(T)`|
+|`||(T)`|`or(T)`|
+|`[](T)`|`[](T)`|
+|`()(T...)`|`call(*T)`|
+
+The following C++ operators are ignored: `=(T)`, `<=>(T)`, `&()`, `->()`,
+`->*(T)`, `,(T)`.
+
+The following Crystal operators are overloadable, but unused by Bindgen:
+`&+`, `&-`, `&+(T)`, `&-(T)`, `&*(T)`, `&**(T)`, `//(T)`, `===(T)`, `<=>(T)`,
+`[]?(*T)`, `[]=(*T, U)`.
+
 ### §2.2 Arguments
 
 #### §2.2.1 Conversion
@@ -544,12 +588,17 @@ generated methods may use custom markers to distinguish them.
 * Property methods use either `GETTER` or `SETTER` (see §2.4)
 * Constructors use `CONSTRUCT`
 * Destructors use `DESTRUCT`
+* Overloaded operators use `OPERATOR`, followed by a name that uniquely
+  identifies the operator
 
 #### Examples
 
-1. Member method `void Foo::bar(int *&) -> bg_Foo_bar_int_XR`
-2. Static method: `void Foo::bar(std::string) -> bg_Foo_STATIC_bar_std__string`
-3. Method without arguments: `void Foo::bar() -> bg_Foo_bar_` (Trailing `_`)
+1. Member method `void Foo::bar(int *&)` -> `bg_Foo_bar_int_XR`
+2. Static method: `void Foo::bar(std::string)` ->
+   `bg_Foo_STATIC_bar_std__string`
+3. Method without arguments: `void Foo::bar()` -> `bg_Foo_bar_` (Trailing `_`)
+4. Operator method: `bool Foo::operator==(const Foo &)` ->
+   `bg_Foo__OPERATOR_eq_const_Foo_R`
 
 ### §3.2 Structures
 

--- a/TEMPLATE.yml
+++ b/TEMPLATE.yml
@@ -37,6 +37,7 @@ processors:
   - macros # Support for macro mapping
   - functions # Add non-class functions
   - instance_properties # Add property methods for static and instance members
+  - operators # Support for overloaded operators
   - filter_methods # Throw out filtered methods
   - extern_c # Directly bind to pure C functions
   - instantiate_containers # Actually instantiate containers

--- a/clang/include/structures.hpp
+++ b/clang/include/structures.hpp
@@ -97,6 +97,7 @@ struct Method {
 		MemberMethod,
 		StaticMethod,
 		Operator, // Overloaded operator
+		ConversionOperator, // Conversion operator
 		Signal, // Qt signal
 	};
 

--- a/clang/src/record_match_handler.cpp
+++ b/clang/src/record_match_handler.cpp
@@ -68,8 +68,7 @@ bool RecordMatchHandler::runOnMethod(Method &m, Class &klass, const clang::CXXMe
 		if (method->getOverloadedOperator() != clang::OO_None) {
 			m.type = Method::Operator;
 		} else if (auto conv = llvm::dyn_cast<clang::CXXConversionDecl>(method)) {
-			m.type = Method::Operator; // TODO: Add conversion method support.
-
+			m.type = Method::ConversionOperator; // TODO: Add conversion method support.
 		} else if (isSignal && m.type == Method::MemberMethod && method->isUserProvided()) {
 			m.type = Method::Signal;
 		}

--- a/clang/src/structures.cpp
+++ b/clang/src/structures.cpp
@@ -108,6 +108,7 @@ JsonStream &operator<<(JsonStream &s, Method::MethodType value) {
 		case Method::MemberMethod: return s << "MemberMethod";
 		case Method::StaticMethod: return s << "StaticMethod";
 		case Method::Operator: return s << "Operator";
+		case Method::ConversionOperator: return s << "ConversionOperator";
 		case Method::Signal: return s << "Signal";
 		default: return s << "BUG IN BINDGEN";
 	}

--- a/spec/integration/basic.cpp
+++ b/spec/integration/basic.cpp
@@ -31,6 +31,56 @@ public:
   const IgnoreMe *ignoreByReturnCPtr() { return new IgnoreMe(); }
 };
 
+struct Ops {
+  int operator+  (int x) const { return x * 1; }
+  int operator-  (int x) const { return x * 2; }
+  int operator*  (int x) const { return x * 3; }
+  int operator/  (int x) const { return x * 4; }
+  int operator%  (int x) const { return x * 5; }
+  int operator&  (int x) const { return x * 6; }
+  int operator|  (int x) const { return x * 7; }
+  int operator^  (int x) const { return x * 8; }
+  int operator<< (int x) const { return x * 9; }
+  int operator>> (int x) const { return x * 10; }
+  int operator&& (int x) const { return x * 11; }
+  int operator|| (int x) const { return x * 12; }
+  int operator== (int x) const { return x * 13; }
+  int operator!= (int x) const { return x * 14; }
+  int operator<  (int x) const { return x * 15; }
+  int operator>  (int x) const { return x * 16; }
+  int operator<= (int x) const { return x * 17; }
+  int operator>= (int x) const { return x * 18; }
+  int operator[] (int x) const { return x * 19; }
+
+  int operator+= (int x) const { return x * 101; }
+  int operator-= (int x) const { return x * 102; }
+  int operator*= (int x) const { return x * 103; }
+  int operator/= (int x) const { return x * 104; }
+  int operator%= (int x) const { return x * 105; }
+  int operator&= (int x) const { return x * 106; }
+  int operator|= (int x) const { return x * 107; }
+  int operator^= (int x) const { return x * 108; }
+  int operator<<=(int x) const { return x * 109; }
+  int operator>>=(int x) const { return x * 110; }
+
+//  auto operator<=>(const Ops &) const = default;
+
+  int operator+() const { return 10001; }
+  int operator-() const { return 10002; }
+  int operator*() const { return 10003; }
+  int operator~() const { return 10004; }
+  int operator!() const { return 10005; }
+  int operator++() const { return 10006; }
+  int operator--() const { return 10007; }
+  int operator++(int) const { return 10008; }
+  int operator--(int) const { return 10009; }
+
+  int operator()() const { return 20001; }
+  int operator()(int) const { return 20002; }
+  int operator()(int, int) const { return 20003; }
+  int operator()(bool) const { return 20004; }
+};
+
 class TypeConversion {
 public:
 

--- a/spec/integration/basic.yml
+++ b/spec/integration/basic.yml
@@ -4,6 +4,7 @@
 
 classes:
   Adder: AdderWrap
+  Ops: Ops
   ImplicitConstructor: ImplicitConstructor
   Aggregate: Aggregate
   PrivateConstructor: PrivateConstructor

--- a/spec/integration/basic_spec.cr
+++ b/spec/integration/basic_spec.cr
@@ -11,6 +11,56 @@ describe "a basic C++ wrapper" do
         it "supports member methods" do
           Test::AdderWrap.new(4).sum(5).should eq(9)
         end
+
+        it "supports member operators" do
+          subject = Test::Ops.new
+
+          (subject +   1).should eq(1)
+          (subject -   2).should eq(4)
+          (subject *   3).should eq(9)
+          (subject /   4).should eq(16)
+          (subject %   5).should eq(25)
+          (subject &   6).should eq(36)
+          (subject |   7).should eq(49)
+          (subject ^   8).should eq(64)
+          (subject <<  9).should eq(81)
+          (subject >> 10).should eq(100)
+          subject.and(11).should eq(121)
+          subject.or(12).should eq(144)
+          (subject == 13).should eq(169)
+          (subject != 14).should eq(196)
+          (subject <  15).should eq(225)
+          (subject >  16).should eq(256)
+          (subject <= 17).should eq(289)
+          (subject >= 18).should eq(324)
+          subject[19].should eq(361)
+
+          subject.add!(1).should eq(101)
+          subject.sub!(2).should eq(204)
+          subject.mul!(3).should eq(309)
+          subject.div!(4).should eq(416)
+          subject.mod!(5).should eq(525)
+          subject.bit_and!(6).should eq(636)
+          subject.bit_or!(7).should eq(749)
+          subject.bit_xor!(8).should eq(864)
+          subject.lshift!(9).should eq(981)
+          subject.rshift!(10).should eq(1100)
+
+          (+subject).should eq(10001)
+          (-subject).should eq(10002)
+          subject.deref.should eq(10003)
+          (~subject).should eq(10004)
+          subject.not.should eq(10005)
+          subject.succ!.should eq(10006)
+          subject.pred!.should eq(10007)
+          subject.post_succ!.should eq(10008)
+          subject.post_pred!.should eq(10009)
+
+          subject.call.should eq(20001)
+          subject.call(0).should eq(20002)
+          subject.call(0, 0).should eq(20003)
+          subject.call(false).should eq(20004)
+        end
       end
 
       context "argument-less default constructor" do

--- a/src/bindgen/crystal.cr
+++ b/src/bindgen/crystal.cr
@@ -14,5 +14,13 @@ module Bindgen
       pointerof sizeof instance_sizeof as as? typeof
       super private protected asm uninitialized nil?
     ]
+
+    # All (overridable) Crystal operators
+    OPERATORS = %w[
+      + &+ - &- * &* / // % ** &**
+      == != < <= > >= <=> === =~ !~
+      ~ & | ^ << >>
+      [] []? []=
+    ]
   end
 end

--- a/src/bindgen/parser/class.cr
+++ b/src/bindgen/parser/class.cr
@@ -122,7 +122,7 @@ module Bindgen
       def each_wrappable_method
         @methods.each do |method|
           next if method.private?
-          next if method.operator?           # TODO: Support Operators!
+          next if method.name == "operator=" # TODO: Support assignments!
           next if method.copy_constructor?   # TODO: Support copy constructors!
           next if method.has_move_semantics? # Move semantics are hard to wrap.
 

--- a/src/bindgen/parser/class.cr
+++ b/src/bindgen/parser/class.cr
@@ -122,9 +122,10 @@ module Bindgen
       def each_wrappable_method
         @methods.each do |method|
           next if method.private?
-          next if method.name == "operator=" # TODO: Support assignments!
-          next if method.copy_constructor?   # TODO: Support copy constructors!
-          next if method.has_move_semantics? # Move semantics are hard to wrap.
+          next if method.name == "operator="  # TODO: Support assignments!
+          next if method.conversion_operator? # TODO: Support conversions!
+          next if method.copy_constructor?    # TODO: Support copy constructors!
+          next if method.has_move_semantics?  # Move semantics are hard to wrap.
 
           # Don't try to wrap copy-constructors in an abstract class.
           next if abstract? && method.copy_constructor?

--- a/src/bindgen/parser/method.cr
+++ b/src/bindgen/parser/method.cr
@@ -421,12 +421,10 @@ module Bindgen
         false # This method is fine.
       end
 
-      # Checks if this method needs to be fixed up.  Returns the fixed method
-      # if any of the following criteria is met:
-      #
-      # * The method is a post-increment or post-decrement method which takes
-      #   a placeholder `int` argument in C++.
-      def fix_up? : Method?
+      # Checks if this method is a post-increment or post-decrement method that
+      # takes a placeholder `int` argument.  If true, returns a copy of this
+      # method with the `int` argument removed.
+      def fix_post_succ_or_pred? : Method?
         return unless operator?
         return unless @name == "operator++" || @name == "operator--"
         return unless @arguments.size == 1 && @arguments[0].full_name == "int"
@@ -490,8 +488,8 @@ module Bindgen
         return "call" if name == "operator()"
 
         case @arguments.size
-        when 0 then to_crystal_operator1_name(name)
-        when 1 then to_crystal_operator2_name(name)
+        when 0 then to_crystal_unary_operator_name(name)
+        when 1 then to_crystal_binary_operator_name(name)
         else
           raise "Unexpected operator #{name.inspect}"
         end
@@ -509,15 +507,15 @@ module Bindgen
         end
 
         case @arguments.size
-        when 0 then binding_operator1_name
-        when 1 then binding_operator2_name
+        when 0 then binding_unary_operator_name
+        when 1 then binding_binary_operator_name
         else
           raise "Unexpected operator #{@name.inspect}"
         end
       end
 
       # Converts *name* to a unary operator method in Crystal wrappers.
-      private def to_crystal_operator1_name(name)
+      private def to_crystal_unary_operator_name(name)
         case name
         when "operator++" then "succ!"
         when "operator--" then "pred!"
@@ -529,7 +527,7 @@ module Bindgen
       end
 
       # Name of the unary operator method in C++ and Crystal bindings.
-      private def binding_operator1_name
+      private def binding_unary_operator_name
         case @name
         when "operator++" then "succ"
         when "operator--" then "pred"
@@ -544,7 +542,7 @@ module Bindgen
       end
 
       # Converts *name* to a binary operator method in Crystal wrappers.
-      private def to_crystal_operator2_name(name)
+      private def to_crystal_binary_operator_name(name)
         case name
         # compound assignment operators
         when "operator="   then "assign!"
@@ -571,7 +569,7 @@ module Bindgen
       end
 
       # Name of the binary operator method in C++ and Crystal bindings.
-      private def binding_operator2_name
+      private def binding_binary_operator_name
         case @name
         when "operator="   then "assign"
         when "operator+="  then "add_assign"

--- a/src/bindgen/parser/method.cr
+++ b/src/bindgen/parser/method.cr
@@ -20,6 +20,7 @@ module Bindgen
         StaticGetter
         StaticSetter
         Operator
+        ConversionOperator
 
         # Qt signal
         Signal
@@ -126,7 +127,7 @@ module Bindgen
       delegate constructor?, aggregate_constructor?, copy_constructor?,
         any_constructor?, member_method?, member_getter?, member_setter?,
         static?, static_method?, static_getter?, static_setter?, signal?,
-        operator?, destructor?, to: @type
+        operator?, conversion_operator?, destructor?, to: @type
       delegate public?, protected?, private?, to: @access
 
       def_equals_and_hash @type, @name, @class_name, @access, @arguments,

--- a/src/bindgen/processor.cr
+++ b/src/bindgen/processor.cr
@@ -25,6 +25,7 @@ module Bindgen
       "macros",
       "functions",
       "instance_properties",
+      "operators",
       "filter_methods",
       # "auto_container_instantiation", # Not stable yet
       "extern_c",

--- a/src/bindgen/processor/filter_methods.cr
+++ b/src/bindgen/processor/filter_methods.cr
@@ -1,11 +1,16 @@
 module Bindgen
   module Processor
-    # Processor removing methods that are to be ignored.
+    # Processor removing methods that are to be ignored.  Also performs fix-ups
+    # on certain methods.
     #
     # Right now, methods can be ignored by any of:
     # 1. Ignoring a type the method uses as argument or result type
     # 2. By adding the name to `type.CLASS.ignore_methods`
     # 3. Methods using anonymous types are always ignored
+    #
+    # The fix-ups include:
+    # 1. Removing the integer arguments of overloaded post-increment and
+    #    post-decrement operators.
     class FilterMethods < Base
       include Graph::Visitor::MayDelete
 
@@ -16,6 +21,7 @@ module Bindgen
 
       def visit_method(method : Graph::Method)
         m = method.origin
+        host = method.parent
 
         # Rule 1: Ignored types
         remove = m.filtered?(@db)
@@ -30,8 +36,23 @@ module Bindgen
         remove ||= type_ignored?(m.return_type)
         remove ||= m.arguments.any? { |arg| type_ignored?(arg) }
 
+        # Rule 4: Fix-ups
+        if !remove
+          fixed = m.fix_up?
+          remove ||= !fixed.nil?
+        end
+
         # Remove if ignored
         remove_method(method) if remove
+
+        # Insert the new method if fix-up is required
+        if fixed
+          Graph::Method.new(
+            origin: fixed,
+            name: method.name,
+            parent: host,
+          )
+        end
       end
 
       # Removes the *method* from its parent.

--- a/src/bindgen/processor/filter_methods.cr
+++ b/src/bindgen/processor/filter_methods.cr
@@ -1,16 +1,11 @@
 module Bindgen
   module Processor
-    # Processor removing methods that are to be ignored.  Also performs fix-ups
-    # on certain methods.
+    # Processor removing methods that are to be ignored.
     #
     # Right now, methods can be ignored by any of:
     # 1. Ignoring a type the method uses as argument or result type
     # 2. By adding the name to `type.CLASS.ignore_methods`
     # 3. Methods using anonymous types are always ignored
-    #
-    # The fix-ups include:
-    # 1. Removing the integer arguments of overloaded post-increment and
-    #    post-decrement operators.
     class FilterMethods < Base
       include Graph::Visitor::MayDelete
 
@@ -21,7 +16,6 @@ module Bindgen
 
       def visit_method(method : Graph::Method)
         m = method.origin
-        host = method.parent
 
         # Rule 1: Ignored types
         remove = m.filtered?(@db)
@@ -36,23 +30,8 @@ module Bindgen
         remove ||= type_ignored?(m.return_type)
         remove ||= m.arguments.any? { |arg| type_ignored?(arg) }
 
-        # Rule 4: Fix-ups
-        if !remove
-          fixed = m.fix_up?
-          remove ||= !fixed.nil?
-        end
-
         # Remove if ignored
         remove_method(method) if remove
-
-        # Insert the new method if fix-up is required
-        if fixed
-          Graph::Method.new(
-            origin: fixed,
-            name: method.name,
-            parent: host,
-          )
-        end
       end
 
       # Removes the *method* from its parent.

--- a/src/bindgen/processor/operators.cr
+++ b/src/bindgen/processor/operators.cr
@@ -1,0 +1,36 @@
+module Bindgen
+  module Processor
+    # Processor performing special handling for overloaded operators.
+    #
+    # Currently, the handling includes:
+    # 1. Removing the integer arguments of overloaded post-increment and
+    #    post-decrement operators.
+    class Operators < Base
+      include Graph::Visitor::MayDelete
+
+      def visit_method(method : Graph::Method)
+        if fixed = method.origin.fix_post_succ_or_pred?
+          new_node = Graph::Method.new(
+            origin: fixed,
+            name: method.name,
+            parent: method.parent,
+          )
+
+          replace_node(method, with: new_node)
+        end
+      end
+
+      # Replaces *old_node* from its parent with *new_node*.  Both nodes must
+      # belong to the same parent already.
+      private def replace_node(old_node, with new_node)
+        parent = old_node.parent.as(Graph::Container)
+        nodes = parent.nodes
+
+        old_pos = nodes.index(&.same?(old_node)).not_nil!
+        new_pos = nodes.index(&.same?(new_node)).not_nil!
+        nodes[old_pos] = new_node
+        nodes.delete_at(new_pos)
+      end
+    end
+  end
+end

--- a/src/bindgen/processor/sanity_check.cr
+++ b/src/bindgen/processor/sanity_check.cr
@@ -207,14 +207,14 @@ module Bindgen
 
       # Checks if *node* has a valid camel-case name.  If not, adds an error.
       private def check_valid_camel_case_name!(node)
-        unless CAMEL_CASE_RX.match(node.name)
+        unless CAMEL_CASE_RX.matches?(node.name)
           add_error(node, "Invalid #{node.kind_name.downcase} name #{node.name.inspect}")
         end
       end
 
       # Checks if *node* has a valid constant name.  If not, adds an error.
       private def check_valid_constant_name!(node)
-        unless CONSTANT_RX.match(node.name)
+        unless CONSTANT_RX.matches?(node.name)
           add_error(node, "Invalid #{node.kind_name.downcase} name #{node.name.inspect}")
         end
       end
@@ -223,8 +223,10 @@ module Bindgen
       private def check_method_name!(node)
         return if node.name.empty? # Accept initializers
 
-        unless METHOD_NAME_RX.match(node.origin.crystal_name)
-          add_error(node, "Invalid #{node.kind_name.downcase} name #{node.name.inspect}")
+        unless METHOD_NAME_RX.matches?(node.origin.crystal_name)
+          unless Crystal::OPERATORS.includes?(node.origin.crystal_name)
+            add_error(node, "Invalid #{node.kind_name.downcase} name #{node.name.inspect}")
+          end
         end
       end
     end


### PR DESCRIPTION
Wraps a lot of overloaded operators, provided they are defined inside a C++ class body. Some operators cannot be overloaded in Crystal (most notably the compound assignments), so they are renamed to normal methods containing `!` in their names, see SPEC.md for the list of renamings. A few details have been left out for separate PRs in the future:

* Non-member overloaded operators can be parsed, but the general case requires reopening core Crystal classes if the left operand is not a wrapped class, e.g. [`QVector3D` multiplication](https://doc.qt.io/qt-5/qvector3d.html#operator-2a).
* `operator=` needs special care, due to its relation with copy constructors. It would probably be called `assign!`.
* Although not limited to operators, `operator[]` usually has both non-const and const overloads and Bindgen will always select the former. This becomes a problem if they return entirely different types.
* Wrappers do not gain `<=>` or include `Comparable` even if all 6 relational operators are defined. This is best done in the config, since each type may use its own comparison category. C++20's `operator<=>` is not supported either.
* `operator&()` may conflict with the cookbook, so I left it out. (That said, the C++ wrappers should be using `std::addressof` instead.)

On Qt almost all the additions are relational operators. Some notable exceptions are `QRect` (union / intersection / margins), `QStringList` (its `operator+` and `operator<<` are class members), and `QDir` (has `operator[]`).