### PR TITLE
Use module instead of abstract base class for instantiated containers

### DIFF
--- a/assets/glue.cr
+++ b/assets/glue.cr
@@ -90,7 +90,7 @@ module BindgenHelper
   # Additionally, there's `#<<`.  Other than that, the container type is not
   # meant to be used for storage, but for data transmission between the C++
   # and the Crystal world.  Don't let that discourage you though.
-  abstract class SequentialContainer(T)
+  module SequentialContainer(T)
     include Indexable(T)
 
     # `#unsafe_fetch` and `#size` will be implemented by the wrapper class.

--- a/src/bindgen/generator/crystal.cr
+++ b/src/bindgen/generator/crystal.cr
@@ -33,6 +33,7 @@ module Bindgen
         suffix = "< #{klass.base_class}" if klass.base_class
 
         code_block scope, prefix, "class", klass.name, suffix do
+          write_included_modules(klass.included_modules)
           write_instance_variables(klass.instance_variables)
           super
         end
@@ -44,8 +45,17 @@ module Bindgen
         puts "#{constant.name} = #{value}"
       end
 
+      # Includes the *modules* in the current open scope.
+      private def write_included_modules(modules)
+        modules.each do |mod|
+          puts "include #{mod}"
+        end
+
+        puts "" unless modules.empty?
+      end
+
       # Writes the instance *variables* into the current open scope.
-      def write_instance_variables(variables)
+      private def write_instance_variables(variables)
         typer = Bindgen::Crystal::Typename.new(@db)
 
         variables.each do |name, result|

--- a/src/bindgen/graph/class.cr
+++ b/src/bindgen/graph/class.cr
@@ -32,7 +32,7 @@ module Bindgen
 
       # List of included Crystal modules.  Used by wrapper classes only, and may
       # point at modules outside the graph.  Ignored by C++ structs.
-      getter included_modules = [] of String
+      getter included_modules = Set(String).new
 
       # Is this class abstract?
       property? abstract : Bool = false

--- a/src/bindgen/graph/class.cr
+++ b/src/bindgen/graph/class.cr
@@ -30,6 +30,10 @@ module Bindgen
       # point at types outside the graph.
       property base_class : String?
 
+      # List of included Crystal modules.  Used by wrapper classes only, and may
+      # point at modules outside the graph.  Ignored by C++ structs.
+      getter included_modules = [] of String
+
       # Is this class abstract?
       property? abstract : Bool = false
 

--- a/src/bindgen/processor/instantiate_containers.cr
+++ b/src/bindgen/processor/instantiate_containers.cr
@@ -8,11 +8,11 @@ module Bindgen
       # generated `#size` method, and `#unsafe_fetch` of sequential containers.
       CPP_INTEGER_TYPE = "int"
 
-      # Base class of sequential containers
-      SEQUENTIAL_BASECLASS = "BindgenHelper::SequentialContainer"
+      # Module for sequential containers
+      SEQUENTIAL_MODULE = "BindgenHelper::SequentialContainer"
 
-      # Base class of associative containers
-      ASSOCIATIVE_BASECLASS = "BindgenHelper::AssociativeContainer"
+      # Module for associative containers
+      ASSOCIATIVE_MODULE = "BindgenHelper::AssociativeContainer"
 
       def process(graph : Graph::Node, _doc : Parser::Document)
         root = graph.as(Graph::Container)
@@ -54,14 +54,14 @@ module Bindgen
 
         graph = builder.build_class(klass, klass.name, root)
         graph.set_tag(Graph::Class::FORCE_UNWRAP_VARIABLE_TAG)
-        graph.base_class = container_base_class(SEQUENTIAL_BASECLASS, var_type)
+        graph.included_modules << container_module(SEQUENTIAL_MODULE, var_type)
       end
 
-      # Generates the Crystal base-class name of a container class.
-      private def container_base_class(kind, *types)
+      # Generates the Crystal module name of a container class.
+      private def container_module(kind, *types)
         pass = Crystal::Pass.new(@db)
         typer = Crystal::Typename.new(@db)
-        args = types.each.map { |t| typer.full pass.to_wrapper(t) }.join(", ")
+        args = types.map { |t| typer.full pass.to_wrapper(t) }.join(", ")
 
         "#{kind}(#{args})"
       end
@@ -157,8 +157,8 @@ module Bindgen
       # Takes a `Configuration::Container` and returns a `Parser::Class` for a
       # specific *instantiation*.
       #
-      # Note: The returned class doesn't inherit from anything.  For the crystal
-      # generator, see `CrystalGenerator#container_baseclass`.
+      # Note: The returned class doesn't include any modules.  This is done on
+      # the `Graph::Class` of the Crystal wrapper, see `#container_module`.
       private def container_class(container, instantiation : Enumerable(Parser::Type)) : Parser::Class
         suffix = instantiation.map(&.mangled_name).join("_")
         klass_type = Parser::Type.parse(container.class)


### PR DESCRIPTION
Turns `BindgenHelper::SequentialContainer` into a module. This serves two purposes:
* It prevents Crystal from reducing unions of possibly unrelated containers into `SequentialContainer`.
* It frees up the Crystal base class so that actual inheritance of container wrappers can be represented, should it be done in the future (e.g. `Container_QQueue_int < Container_QList_int`).
