### PR TITLE
Support type substitution of template types

### DIFF
--- a/spec/bindgen/parser/type_spec.cr
+++ b/spec/bindgen/parser/type_spec.cr
@@ -53,7 +53,7 @@ describe Bindgen::Parser::Type do
       type.reference?.should be_false
       type.pointer.should eq(1)
       type.base_name.should eq("int")
-      type.full_name.should eq("int*")
+      type.full_name.should eq("int *")
     end
 
     it "recognizes 'int &'" do
@@ -71,7 +71,7 @@ describe Bindgen::Parser::Type do
       type.reference?.should be_true
       type.pointer.should eq(1)
       type.base_name.should eq("int")
-      type.full_name.should eq("int&")
+      type.full_name.should eq("int &")
     end
 
     it "recognizes 'const int *'" do
@@ -101,9 +101,98 @@ describe Bindgen::Parser::Type do
       type.full_name.should eq("const int **")
     end
 
+    it "recognizes `Container<>`" do
+      type = parse("Container<>")
+      type.base_name.should eq("Container<>")
+      type.full_name.should eq("Container<>")
+      template = type.template
+      template.should_not be_nil
+      template.try(&.base_name).should eq("Container")
+      template.try(&.full_name).should eq("Container<>")
+      template.try(&.arguments.empty?).should be_true
+    end
+
+    it "recognizes `Container<int>`" do
+      type = parse("Container<int>")
+      type.base_name.should eq("Container<int>")
+      type.full_name.should eq("Container<int>")
+      template = type.template
+      template.should_not be_nil
+      template.try(&.base_name).should eq("Container")
+      template.try(&.full_name).should eq("Container<int>")
+      template.try(&.arguments.size).should eq(1)
+      template.try(&.arguments[0]).should eq(parse("int"))
+    end
+
+    it "recognizes `Container<const int *>`" do
+      type = parse("Container<const int *>")
+      type.base_name.should eq("Container<const int *>")
+      type.full_name.should eq("Container<const int *>")
+      template = type.template
+      template.should_not be_nil
+      template.try(&.base_name).should eq("Container")
+      template.try(&.full_name).should eq("Container<const int *>")
+      template.try(&.arguments.size).should eq(1)
+      template.try(&.arguments[0]).should eq(parse("const int *"))
+    end
+
+    it "recognizes `Container<int, bool>`" do
+      type = parse("Container<int, bool>")
+      type.base_name.should eq("Container<int, bool>")
+      type.full_name.should eq("Container<int, bool>")
+      template = type.template
+      template.should_not be_nil
+      template.try(&.base_name).should eq("Container")
+      template.try(&.full_name).should eq("Container<int, bool>")
+      template.try(&.arguments.size).should eq(2)
+      template.try(&.arguments[0]).should eq(parse("int"))
+      template.try(&.arguments[1]).should eq(parse("bool"))
+    end
+
+    it "recognizes `Container<Container<int> >`" do
+      type = parse("Container<Container<int> >")
+      type.base_name.should eq("Container<Container<int> >")
+      type.full_name.should eq("Container<Container<int> >")
+      template = type.template
+      template.should_not be_nil
+      template.try(&.base_name).should eq("Container")
+      template.try(&.full_name).should eq("Container<Container<int>>")
+      template.try(&.arguments.size).should eq(1)
+      template.try(&.arguments[0]).should eq(parse("Container<int>"))
+    end
+
+    it "recognizes `Container<Container<int>>`" do
+      type = parse("Container<Container<int>>")
+      type.base_name.should eq("Container<Container<int>>")
+      type.full_name.should eq("Container<Container<int>>")
+      template = type.template
+      template.should_not be_nil
+      template.try(&.base_name).should eq("Container")
+      template.try(&.full_name).should eq("Container<Container<int>>")
+      template.try(&.arguments.size).should eq(1)
+      template.try(&.arguments[0]).should eq(parse("Container<int>"))
+    end
+
+    it "recognizes `Container<const Container<int> &>`" do
+      type = parse("Container<const Container<int> &>")
+      type.base_name.should eq("Container<const Container<int> &>")
+      type.full_name.should eq("Container<const Container<int> &>")
+      template = type.template
+      template.should_not be_nil
+      template.try(&.base_name).should eq("Container")
+      template.try(&.full_name).should eq("Container<const Container<int> &>")
+      template.try(&.arguments.size).should eq(1)
+      template.try(&.arguments[0]).should eq(parse("const Container<int> &"))
+    end
+
     it "supports pointer depth offset" do
       parse("int", 1).pointer.should eq(1)
       parse("int *", 1).pointer.should eq(2)
+
+      # don't add offset to template argument types
+      type = parse("Container<int>", 1)
+      type.pointer.should eq(1)
+      type.template.not_nil!.arguments[0].pointer.should eq(0)
     end
   end
 end

--- a/src/bindgen/parser/argument.cr
+++ b/src/bindgen/parser/argument.cr
@@ -101,6 +101,28 @@ module Bindgen
         )
       end
 
+      # Performs type substitution on the type part of this argument using the
+      # given *replacements*.
+      def substitute_type(replacements : Hash(String, Type)) : Argument
+        Argument.new(
+          name: @name,
+          type: substitute(replacements),
+          has_default: @has_default,
+          value: @value,
+        )
+      end
+
+      # Substitutes all uses of *name* on the type part of this argument with
+      # the given *type*.
+      def substitute_type(name : String, with type : Type) : Argument
+        Argument.new(
+          name: @name,
+          type: substitute(name, type),
+          has_default: @has_default,
+          value: @value,
+        )
+      end
+
       # Checks if the type-part of this equals the type-part of *other*.
       def type_equals?(other : Type)
         {% for i in %i[base_name full_name const reference move builtin void pointer template] %}

--- a/src/bindgen/parser/type/cpp_type_parser.cr
+++ b/src/bindgen/parser/type/cpp_type_parser.cr
@@ -1,0 +1,138 @@
+require "string_scanner"
+
+module Bindgen
+  module Parser
+    class Type
+      # Parser for qualified C++ type-names.  It's really stupid though.
+      private class CppTypeParser
+        # Regex that matches the opening of a template argument list.
+        OPEN_RX = /</
+
+        # Regex that matches the closing of a template argument list, including
+        # an optional suffix that forms part of the preceding template type.
+        CLOSE_RX = />([^,>]*)/
+
+        # Regex matching everything that does not delimit a template argument
+        # list.
+        NEITHER_RX = /[^<>]+/
+
+        def parse(type_name : String, pointer_depth : Int32 = 0)
+          parse_type(type_name, pointer_depth)
+        end
+
+        # Parses a C++ type.  Recursively parses all templates contained within,
+        # unless a template instantiation is explicitly given.
+        private def parse_type(type_name, pointer_depth, template = nil) : Type
+          name = type_name.strip # Clean the name
+          reference = false
+          const = false
+          pointer = 0
+
+          # Is it const-qualified?
+          if name.starts_with?("const ")
+            const = true
+            name = name[6..-1] # Remove `const `
+          end
+
+          # Is it a reference?
+          if name.ends_with?('&')
+            reference = true
+            pointer_depth += 1
+            name = name[0..-2] # Remove ampersand
+          end
+
+          # Is it a pointer?
+          while name.ends_with?('*')
+            pointer += 1
+            pointer_depth += 1
+            name = name[0..-2] # Remove star
+          end
+
+          name = name.strip
+
+          # Is it a template?
+          if template
+            # Adjust template name to remove `const` etc.
+            template = Template.new(
+              base_name: name.match(OPEN_RX).try(&.pre_match) || name,
+              full_name: name,
+              arguments: template.arguments,
+            )
+          elsif name =~ OPEN_RX || name =~ CLOSE_RX
+            template = parse_template(name.strip)
+          end
+
+          typer = Cpp::Typename.new
+
+          Type.new( # Build the `Type`
+            const: const,
+            move: false,
+            reference: reference,
+            builtin: false, # Oh well
+            void: (name == "void"),
+            pointer: pointer_depth,
+            base_name: name,
+            full_name: typer.full(name, const, pointer, reference),
+            template: template,
+            nilable: false,
+          )
+        end
+
+        # Tree structure of a template.
+        alias TemplateTree = Type | Array(TemplateTree)
+
+        # this won't work for some reason
+        # alias TemplateTree = Array(Type | TemplateTree)
+
+        # Parses a C++ template.  Recursively parses all types within.
+        # *type_name* is expected to be a plain type (without `const`, pointers,
+        # or references).
+        private def parse_template(type_name) : Template?
+          typer = Cpp::Typename.new
+          scanner = StringScanner.new(type_name)
+          top = [] of TemplateTree
+          stack = [top]
+
+          until scanner.eos?
+            if scanner.scan(OPEN_RX)
+              top = [] of TemplateTree
+              stack << top
+            elsif scanner.scan(CLOSE_RX)
+              template_args = stack.pop.map(&.as(Type))
+
+              raise "Extra closing bracket" if stack.empty?
+              top = stack.last
+              template_type = top.pop?
+              raise "Template argument list without template name" unless
+                template_type.is_a?(Type)
+
+              suffix = scanner[1]
+              arg_list = template_args.map(&.full_name)
+              base_name = template_type.full_name
+              full_name = "#{typer.template_class base_name, arg_list}#{suffix}".strip
+              template = Template.new(
+                base_name: base_name,
+                full_name: full_name,
+                arguments: template_args,
+              )
+
+              type = parse_type(full_name, 0, template)
+              top << type
+            elsif text = scanner.scan(NEITHER_RX)
+              parts = text.split(',', remove_empty: true)
+              types = parts.compact_map do |part|
+                parse_type(part.strip, 0) unless part.blank?
+              end
+              top.concat(types)
+            end
+          end
+
+          raise "Extra opening bracket" unless stack.size == 1
+          raise "Multiple top-level types" unless top.size == 1
+
+          top.first.as(Type).template
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extends Bindgen's type parser to handle C++ templates, and adds methods that replace names in a given type with other types. This PR lays the groundwork for at least 2 scenarios:

* Alias resolution, including in template arguments, e.g. from `const QVector<QRgb> &` to `const QVector<unsigned int> &`, provided `QRgb` is an alias for `unsigned int`. This can be used for the first issue mentioned in #102; before this PR, the most Bindgen could do was resolving one level of aliases in each template argument.
* Template type substitution, e.g. `QVector<const T *>` to `QVector<const QVector<int> *>`, provided `T` is instantiated with `const QVector<int> &` (notice the combination of const-ness and references and pointers). This allows for example the possibility of defining container interfaces in the config files.

The parser and the substitution both fully handle arbitrarily nested templates; the returned `Parser::Type`s respect the template structure at all levels, and should match what would be produced by the Clang parser.