### PR TITLE
Regression: require SequentialContainer(T)#push to accept value of type T

### DIFF
--- a/assets/glue.cr
+++ b/assets/glue.cr
@@ -96,7 +96,7 @@ module BindgenHelper
     # `#unsafe_fetch` and `#size` will be implemented by the wrapper class.
 
     # Adds an element at the end.  Implemented by the wrapper.
-    abstract def push(value)
+    abstract def push(value : T)
 
     # Adds *element* at the end of the container.
     def <<(value : T) : self


### PR DESCRIPTION
`abstract def push(value)` without the type restriction on `value` will no longer work as of crystal-lang/crystal@d44530d, which produces errors such as

```
In tmp/containers.cr:65:20

 65 | abstract def push(value)
                   ^---
Error: abstract `def Test::BindgenHelper::SequentialContainer(T)#push(value)` must be implemented by Test::Container_std__vector_int
```