### PR TITLE
Better support for recursive aliases

### DIFF
--- a/builtin_types.yml
+++ b/builtin_types.yml
@@ -4,29 +4,26 @@
 void: { binding_type: Void, kind: Struct, builtin: true }
 
 # Boolean type
-_Bool: { binding_type: Bool, crystal_type: Bool, cpp_type: bool, kind: Struct, builtin: true }
 bool: { binding_type: Bool, crystal_type: Bool, cpp_type: bool, kind: Struct, builtin: true }
+_Bool: { alias_for: bool }
 
 # Integer types
 char: { binding_type: UInt8, kind: Struct, builtin: true }
 "unsigned char": { binding_type: UInt8, kind: Struct, builtin: true }
+"signed char": { binding_type: Int8, kind: Struct, builtin: true }
 short: { binding_type: Int16, kind: Struct, builtin: true }
 "unsigned short": { binding_type: UInt16, kind: Struct, builtin: true }
 int: { binding_type: Int32, kind: Struct, builtin: true }
-unsigned: { binding_type: UInt32, kind: Struct, builtin: true }
 "unsigned int": { binding_type: UInt32, kind: Struct, builtin: true }
 _Int: { binding_type: Int, crystal_type: Int, cpp_type: int, kind: Struct, builtin: true }
 
 # Long types
-"long": { binding_type: "LibC::Long", kind: Struct, builtin: true }
 "long int": { binding_type: "LibC::Long", kind: Struct, builtin: true }
-"long long": { binding_type: "LibC::LongLong", kind: Struct, builtin: true }
 "long long int": { binding_type: "LibC::LongLong", kind: Struct, builtin: true }
-"unsigned long": { binding_type: "LibC::ULong", kind: Struct, builtin: true }
 "unsigned long int": { binding_type: "LibC::ULong", kind: Struct, builtin: true }
-"unsigned long long": { binding_type: "LibC::ULongLong", kind: Struct, builtin: true }
 "unsigned long long int": { binding_type: "LibC::ULongLong", kind: Struct, builtin: true }
 
+# Fixed-size integer types
 int8_t: { binding_type: Int8, kind: Struct, builtin: true }
 int16_t: { binding_type: Int16, kind: Struct, builtin: true }
 int32_t: { binding_type: Int32, kind: Struct, builtin: true }
@@ -36,12 +33,20 @@ uint16_t: { binding_type: UInt16, kind: Struct, builtin: true }
 uint32_t: { binding_type: UInt32, kind: Struct, builtin: true }
 uint64_t: { binding_type: UInt64, kind: Struct, builtin: true }
 
+# Size types
 size_t: { binding_type: "LibC::SizeT", kind: Struct, builtin: true }
 ssize_t: { binding_type: "LibC::SSizeT", kind: Struct, builtin: true }
 
 # Float types
 float: { binding_type: Float32, kind: Struct, builtin: true }
 double: { binding_type: Float64, kind: Struct, builtin: true }
+
+# Integer types without `int`
+unsigned: { alias_for: "unsigned int" }
+"long": { alias_for: "long int" }
+"long long": { alias_for: "long long int" }
+"unsigned long": { alias_for: "unsigned long int" }
+"unsigned long long": { alias_for: "unsigned long long int" }
 
 # C++ STL
 "std::string":
@@ -77,31 +82,21 @@ else:
   qintptr: { binding_type: Int64, kind: Struct, builtin: true }
   quintptr: { binding_type: UInt64, kind: Struct, builtin: true }
 
-quint8: { binding_type: UInt8, kind: Struct, builtin: true }
-quint16: { binding_type: UInt16, kind: Struct, builtin: true }
-quint32: { binding_type: UInt32, kind: Struct, builtin: true }
-quint64: { binding_type: UInt64, kind: Struct, builtin: true }
-qulonglong: { binding_type: UInt64, kind: Struct, builtin: true }
-qint8: { binding_type: Int8, kind: Struct, builtin: true }
-qint16: { binding_type: Int16, kind: Struct, builtin: true }
-qint32: { binding_type: Int32, kind: Struct, builtin: true }
-qint64: { binding_type: Int64, kind: Struct, builtin: true }
-qlonglong: { binding_type: Int64, kind: Struct, builtin: true }
-qsizetype: { binding_type: "LibC::SizeT", kind: Struct, builtin: true } # Since Qt5.10
+quint8: { alias_for: uint8_t }
+quint16: { alias_for: uint16_t }
+quint32: { alias_for: uint32_t }
+quint64: { alias_for: uint64_t }
+qulonglong: { alias_for: uint64_t }
+qint8: { alias_for: int8_t }
+qint16: { alias_for: int16_t }
+qint32: { alias_for: int32_t }
+qint64: { alias_for: int64_t }
+qlonglong: { alias_for: int64_t }
+qsizetype: { alias_for: size_t } # Since Qt5.10
 
 if_architecture_is_arm: # Only Float32 on ARM
-  qreal: { binding_type: Float32, kind: Struct, builtin: true }
+  qreal: { alias_for: float }
 elsif_architecture_is_armhf:
-  qreal: { binding_type: Float32, kind: Struct, builtin: true }
+  qreal: { alias_for: float }
 else: # Float64 on everything else
-  qreal: { binding_type: Float64, kind: Struct, builtin: true }
-
-# Bindgen specific
-CrystalProc:
-  wrapper_type: Proc
-  binding_type: CrystalProc
-  kind: Struct
-  builtin: true # We don't want a binding alias for this.
-  pass_by: Value
-  wrapper_pass_by: Value
-  from_crystal: "BindgenHelper.wrap_proc(%)"
+  qreal: { alias_for: double }

--- a/spec/bindgen/type_database_spec.cr
+++ b/spec/bindgen/type_database_spec.cr
@@ -4,13 +4,12 @@ private def parse(*args)
   Bindgen::Parser::Type.parse(*args)
 end
 
-describe Bindgen::TypeDatabase do
-  db = Bindgen::TypeDatabase.new(Bindgen::TypeDatabase::Configuration.new, "boehmgc-cpp", with_builtins: false)
+private def new_database
+  Bindgen::TypeDatabase.new(Bindgen::TypeDatabase::Configuration.new, "boehmgc-cpp", with_builtins: false)
+end
 
-  db.add_alias("Recursive", alias_for: "Recursive")
-  db.add_alias("Aliaserer", alias_for: "Aliaser")
-  db.add_alias("Aliaser", alias_for: "Aliasee")
-  db.add("Aliasee", crystal_type: "aliased-thing")
+describe Bindgen::TypeDatabase do
+  db = new_database
   db.add("CppType", cpp_type: "TheCppType", generate_wrapper: false)
   db.add("foo", crystal_type: "value")
   db.add("foo *", crystal_type: "pointer")
@@ -36,9 +35,29 @@ describe Bindgen::TypeDatabase do
     end
 
     context "aliasing" do
-      it "detects simple alias-loops" do
-        expect_raises(Exception, /recursive type-alias/i) do
-          watchdog(1.second) { db["Recursive"]? }
+      db.add_alias("Aliaser", alias_for: "Aliasee")
+      db.add("Aliasee", crystal_type: "aliased-thing")
+
+      it "detects recursive aliases" do
+        expect_raises(Exception, /recursive type alias/i) do
+          db.add_alias("Recursive", alias_for: "Recursive")
+        end
+        expect_raises(Exception, /recursive type alias/i) do
+          db.add_alias("T", alias_for: "T *")
+        end
+        expect_raises(Exception, /recursive type alias/i) do
+          db.add_alias("T", alias_for: "Temp<T>")
+        end
+
+        expect_raises(Exception, /recursive type alias/i) do
+          db2 = new_database
+          db2.add_alias("T", alias_for: "U")
+          db2.add_alias("U", alias_for: "T")
+        end
+        expect_raises(Exception, /recursive type alias/i) do
+          db2 = new_database
+          db2.add_alias("T", alias_for: "U *")
+          db2.add_alias("U", alias_for: "T *")
         end
       end
 
@@ -51,7 +70,11 @@ describe Bindgen::TypeDatabase do
       end
 
       it "finds recursive aliased type" do
+        db.add_alias("Aliaserer", alias_for: "Aliaser")
         db[parse("Aliaserer")].crystal_type.should eq("aliased-thing")
+
+        db.add("temp<Aliasee>", crystal_type: "temp-aliasee")
+        db[parse("temp<Aliaserer>")].crystal_type.should eq("temp-aliasee")
       end
     end
   end
@@ -104,7 +127,7 @@ describe Bindgen::TypeDatabase do
     end
 
     it "creates and returns new rules" do
-      db = Bindgen::TypeDatabase.new(Bindgen::TypeDatabase::Configuration.new, "boehmgc-cpp")
+      db2 = new_database
       db["NewRules"]?.should be_nil
       new_rules = db.get_or_add("NewRules")
       db["NewRules"]?.should be(new_rules)

--- a/spec/bindgen/type_database_spec.cr
+++ b/spec/bindgen/type_database_spec.cr
@@ -5,11 +5,11 @@ private def parse(*args)
 end
 
 describe Bindgen::TypeDatabase do
-  db = Bindgen::TypeDatabase.new(Bindgen::TypeDatabase::Configuration.new, "boehmgc-cpp")
+  db = Bindgen::TypeDatabase.new(Bindgen::TypeDatabase::Configuration.new, "boehmgc-cpp", with_builtins: false)
 
-  db.add("Recursive", alias_for: "Recursive")
-  db.add("Aliaserer", alias_for: "Aliaser")
-  db.add("Aliaser", alias_for: "Aliasee")
+  db.add_alias("Recursive", alias_for: "Recursive")
+  db.add_alias("Aliaserer", alias_for: "Aliaser")
+  db.add_alias("Aliaser", alias_for: "Aliasee")
   db.add("Aliasee", crystal_type: "aliased-thing")
   db.add("CppType", cpp_type: "TheCppType", generate_wrapper: false)
   db.add("foo", crystal_type: "value")

--- a/src/bindgen/cpp/pass.cr
+++ b/src/bindgen/cpp/pass.cr
@@ -40,7 +40,7 @@ module Bindgen
         proc_types.unshift to_cpp(inner_args.first)
 
         proc_args = typer.full(proc_types)
-        typer.template_class("CrystalProc", proc_args)
+        typer.template_class(Parser::Type::CRYSTAL_PROC, proc_args)
       end
 
       # Computes a result for passing *type* from Crystal to C++.
@@ -68,11 +68,15 @@ module Bindgen
         pass_by = TypeDatabase::PassBy::Original
 
         type_name = type.base_name
-        type_name = crystal_proc_name(type) if type.kind.function?
 
-        # If the method expects a value, but we don't copy its structure, we pass
-        # a reference to it instead.
-        if is_val && !is_copied
+        if type.kind.function?
+          type_name = crystal_proc_name(type)
+          pass_by = TypeDatabase::PassBy::Value
+          is_ref = false
+          ptr = 0
+        elsif is_val && !is_copied
+          # If the method expects a value, but we don't copy its structure, we
+          # pass a reference to it instead.
           is_ref = true
           ptr = 0
         end

--- a/src/bindgen/crystal/pass.cr
+++ b/src/bindgen/crystal/pass.cr
@@ -66,7 +66,11 @@ module Bindgen
           end
 
           if type.kind.function?
-            template = Template::ProcFromWrapper.new(type, @db).followed_by(template)
+            type_name = Parser::Type::CRYSTAL_PROC
+            template = Template::ProcFromWrapper.new(type, @db).followed_by(
+              Template.from_string("BindgenHelper.wrap_proc(%)", simple: true).followed_by(template))
+            ptr = 0
+            is_ref = false
           end
 
           ptr += 1 if is_ref # Translate reference to pointer
@@ -103,6 +107,11 @@ module Bindgen
             end
 
             is_ref, ptr = reconfigure_pass_type(rules.crystal_pass_by, is_ref, ptr)
+          end
+
+          if type.kind.function?
+            is_ref = false
+            ptr = 0
           end
 
           ptr += 1 if is_ref # Translate reference to pointer

--- a/src/bindgen/parser/argument.cr
+++ b/src/bindgen/parser/argument.cr
@@ -23,8 +23,8 @@ module Bindgen
 
       def initialize(
         @name, @base_name, @full_name, @const, @reference, @move, @builtin,
-        @void, @pointer, @kind = Type::Kind::Class, @has_default = false,
-        @value = nil, @nilable = false, @variadic = false
+        @void, @pointer, @template, @kind = Type::Kind::Class,
+        @has_default = false, @value = nil, @nilable = false, @variadic = false
       )
       end
 
@@ -44,7 +44,8 @@ module Bindgen
       end
 
       def_equals_and_hash @base_name, @full_name, @const, @reference, @move,
-        @builtin, @void, @pointer, @has_default, @name, @value, @nilable
+        @builtin, @void, @pointer, @has_default, @name, @value, @nilable,
+        @template
 
       # Does this argument have an exposed default value?
       def has_exposed_default?
@@ -73,6 +74,7 @@ module Bindgen
           builtin: @builtin,
           void: @void,
           pointer: @pointer,
+          template: @template,
           kind: @kind,
           has_default: false,
           value: nil,
@@ -94,6 +96,7 @@ module Bindgen
           builtin: @builtin,
           void: @void,
           pointer: @pointer,
+          template: @template,
           kind: @kind,
           has_default: @has_default || other.has_default?,
           value: @value || other.value,

--- a/src/bindgen/parser/class.cr
+++ b/src/bindgen/parser/class.cr
@@ -162,11 +162,7 @@ module Bindgen
 
       # Returns a `Type` referencing this class.
       def as_type(pointer = 1, reference = false, const = false) : Type
-        full_name = name
-        full_name = "const #{name}" if const
-        full_name += "*" * pointer if pointer > 0
-        full_name += "&" if reference
-        pointer += 1 if reference
+        typer = Cpp::Typename.new
 
         kind = case type_kind
         when .struct? then Type::Kind::Struct
@@ -182,8 +178,8 @@ module Bindgen
           void: false,
           builtin: false,
           base_name: name,
-          full_name: full_name,
-          pointer: pointer,
+          full_name: typer.full(name, const, pointer, reference),
+          pointer: pointer + (reference ? 1 : 0),
         )
       end
     end

--- a/src/bindgen/parser/method.cr
+++ b/src/bindgen/parser/method.cr
@@ -380,7 +380,7 @@ module Bindgen
             void: false,
             builtin: false,
             base_name: @class_name,
-            full_name: "#{@class_name}*",
+            full_name: "#{@class_name} *",
             pointer: 1,
           )
         else

--- a/src/bindgen/parser/type.cr
+++ b/src/bindgen/parser/type.cr
@@ -211,6 +211,16 @@ module Bindgen
         end
       end
 
+      # Checks whether this type uses *name* in its base name or any of its
+      # template arguments.  Does not check for template names.
+      def uses_typename?(name : String)
+        if template = @template
+          template.arguments.any?(&.uses_typename?(name))
+        else
+          @base_name == name
+        end
+      end
+
       # Performs type substitution with the given *replacements*.
       #
       # Substitution is performed if this type's base name is exactly one of the

--- a/src/bindgen/processor/function_class.cr
+++ b/src/bindgen/processor/function_class.cr
@@ -163,8 +163,7 @@ module Bindgen
         rules.cpp_type ||= structure
         rules.graph_node = klass
 
-        struct_rules = @db.get_or_add(structure)
-        struct_rules.alias_for ||= klass.name
+        @db.add_alias(structure, klass.name)
       end
     end
   end

--- a/src/bindgen/processor/instantiate_containers.cr
+++ b/src/bindgen/processor/instantiate_containers.cr
@@ -75,7 +75,7 @@ module Bindgen
 
         # Alias e.g. `QList_QObject_X` to `QList<QObject *>`
         if @db[type.base_name]?.nil?
-          @db.get_or_add(type.base_name).alias_for = klass.name
+          @db.add_alias(type.base_name, klass.name)
         end
 
         # On top for C++!

--- a/src/bindgen/processor/virtual_override.cr
+++ b/src/bindgen/processor/virtual_override.cr
@@ -256,7 +256,7 @@ module Bindgen
         wrapper.build(orig_method, target)
       end
 
-      # Adds the `BgInherit` struct for Crystal to *klass*.
+      # Adds the `BgJumptable` struct for Crystal to *klass*.
       private def add_crystal_jumptable_struct(klass)
         build_jumptable_struct(klass, binding) do |method|
           crystal_jumptable_field method
@@ -293,14 +293,9 @@ module Bindgen
       private def cpp_jumptable_field(method) : Call::Result
         m = method.origin
         proc_type = Parser::Type.proc(m.return_type, m.arguments)
-        pass = Cpp::Pass.new(@db)
 
-        Call::Result.new(
-          type: proc_type,
-          type_name: pass.crystal_proc_name(proc_type),
-          reference: false,
-          pointer: 0,
-        )
+        pass = Cpp::Pass.new(@db)
+        pass.to_cpp(proc_type)
       end
 
       # Returns the Crystal type to a `CrystalProc`
@@ -308,12 +303,8 @@ module Bindgen
         m = method.origin
         proc_type = Parser::Type.proc(m.return_type, m.arguments)
 
-        Call::Result.new(
-          type: proc_type,
-          type_name: proc_type.base_name,
-          reference: false,
-          pointer: 0,
-        )
+        pass = Crystal::Pass.new(@db)
+        pass.to_binding(proc_type)
       end
 
       # Adds the `JUMPTABLE` method to *klass*, which will be used to pass the


### PR DESCRIPTION
Improves alias resolution of type names.

After a new alias is added, any internal aliases among the aliases' underlying types are immediately resolved; an alias then becomes recursive only if it refers to its own name. Bindgen now reports recursive aliases on addition, including loops and indirect recursions like `T` -> `const T *` or `std::vector<T>`. Alias resolution for user types is also faster, since type substitution occurs exactly once (in `TypeDatabase#resolve_aliases`).

For this to work correctly across various scenarios, even more `Parser::Type` objects have their full type names canonicalized:

* `#template` always refers to the type name's template arguments. Before this PR, the Clang parser would report types like `std::string` that don't have a template argument list, but whose `#template` refers to the underlying template specialization (in this case `std::basic_string` complete with the char traits and allocator).
* `CrystalProc` is always represented by templated types. The `types` section of the YAML config is not prepared to handle generic types, so `CrystalProc`'s special passing rules are done in the source code itself.
* Some built-in type rules have been replaced by aliases, e.g. `qreal` to `float` or `double`.