### PR TITLE
Automatically instantiate aliased container templates

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -552,6 +552,39 @@ class Point
 end
 ```
 
+### §2.6 Generic types
+
+Only sequential container types are instantiated on the Crystal side, as if each
+container implements the following interface:
+
+```crystal
+module Container(T)
+  include Indexable(T)
+
+  # All containers must be default-constructible
+  # abstract def initialize
+
+  abstract def unsafe_fetch(index : Int) : T
+  abstract def push(value : T) : Void
+  abstract def size : Int32
+
+  def <<(x : T)
+    push(x)
+    self
+  end
+
+  def concat(values : Enumerable(T))
+    values.each { |v| self << v }
+    self
+  end
+end
+```
+
+Bindgen automatically collects all instantiations of each container type that
+appear in method argument types or return types; explicit instantiations may be
+configured with the `containers` section.  Aliases to complete container types
+and container type arguments are both supported.
+
 ## §3. Crystal bindings
 
 ### §3.1 Naming scheme

--- a/clang/find_clang.cr
+++ b/clang/find_clang.cr
@@ -154,7 +154,7 @@ spec_base_content = {
       output: "tmp/{SPEC_NAME}.cr",
     },
   },
-  library: "%/tmp/{SPEC_NAME}.o -lstdc++",
+  library: "%/tmp/{SPEC_NAME}.o -lstdc++ -lgccpp",
   parser:  {
     files:    ["{SPEC_NAME}.cpp"],
     includes: [

--- a/spec/integration/containers.cpp
+++ b/spec/integration/containers.cpp
@@ -1,6 +1,9 @@
 #include <vector>
 #include <string>
 
+typedef std::vector<unsigned char> bytearray;
+typedef unsigned int rgb;
+
 class Containers {
 public:
   std::vector<int> integers() {
@@ -13,6 +16,14 @@ public:
 
   std::vector<std::string> strings() {
     return std::vector<std::string>{ "One", "Two", "Three" };
+  }
+
+  bytearray chars() {
+    return { 0x01, 0x04, 0x09 };
+  }
+
+  std::vector<rgb> palette() {
+    return { 0xFF0000, 0x00FF00, 0x0000FF };
   }
 
   double sum(std::vector<double> list) {

--- a/spec/integration/containers.yml
+++ b/spec/integration/containers.yml
@@ -2,6 +2,7 @@
 
 processors:
   - filter_methods
+  - auto_container_instantiation
   - instantiate_containers
   - default_constructor
   - cpp_wrapper
@@ -17,6 +18,8 @@ containers:
     type: Sequential
     instantiations:
       - [ "int" ]
-      - [ "double" ]
-      - [ "std::string" ]
       - [ "std::vector<int>" ]
+
+types:
+  rgb: { alias_for: "unsigned int" }
+  bytearray: { alias_for: std::vector<unsigned char> }

--- a/spec/integration/containers_spec.cr
+++ b/spec/integration/containers_spec.cr
@@ -17,6 +17,14 @@ describe "container instantiation feature" do
           Test::Containers.new.sum(list).should eq(4.0)
         end
 
+        it "works with auto instantiated container (aliased container)" do
+          Test::Containers.new.chars.to_a.should eq([1u8, 4u8, 9u8])
+        end
+
+        it "works with auto instantiated container (aliased element)" do
+          Test::Containers.new.palette.to_a.should eq([0xFF0000u32, 0x00FF00u32, 0x0000FFu32])
+        end
+
         it "works with nested containers" do
           Test::Containers.new.grid.to_a.map(&.to_a).should eq([[1, 4], [9, 16]])
         end

--- a/src/bindgen/configuration.cr
+++ b/src/bindgen/configuration.cr
@@ -103,7 +103,7 @@ module Bindgen
       property type : Type
 
       # List of instantiations to create.
-      property instantiations : Array(Array(String)) = [] of Array(String)
+      property instantiations = Set(Array(String)).new
 
       # Method to access an element at an index.
       property access_method : String = "at"

--- a/src/bindgen/cpp/method_name.cr
+++ b/src/bindgen/cpp/method_name.cr
@@ -58,10 +58,8 @@ module Bindgen
       # Finds *class_name* in the graph and checks if it's shadow sub-classed in
       # C++.  If so, returns the name of the shadow class.
       private def class_name_for_new(class_name)
-        if klass = @db.try_or(class_name, nil, &.graph_node.as(Graph::Class))
-          klass.cpp_sub_class || class_name
-        else
-          class_name
+        @db.try_or(class_name, class_name) do |rules|
+          rules.graph_node.as?(Graph::Class).try(&.cpp_sub_class)
         end
       end
     end

--- a/src/bindgen/processor/auto_container_instantiation.cr
+++ b/src/bindgen/processor/auto_container_instantiation.cr
@@ -11,8 +11,10 @@ module Bindgen
         m = method.origin
 
         try_add_container_type m.return_type
+        try_add_container_type @db.resolve_aliases m.return_type
         m.arguments.each do |argument|
           try_add_container_type argument
+          try_add_container_type @db.resolve_aliases argument
         end
       end
 
@@ -28,17 +30,17 @@ module Bindgen
         container = @config.containers.find(&.class.== templ.base_name)
         return if container.nil? # Not a configured container type
 
-                  # Check for the correct amount of template arguments.  There may be more
-                  # than those arguments, which are usually allocators.
+        # Check for the correct amount of template arguments.  There may be more
+        # than those arguments, which are usually allocators.
         arg_count = container_type_arguments(container.type)
         return if templ.arguments.size < arg_count
 
         # Add if we don't already know of this instantiation
-        instantiation = templ.arguments[0, arg_count].map(&.full_name)
-
-        unless container.instantiations.includes?(instantiation)
-          container.instantiations << instantiation
+        instantiation = templ.arguments[0...arg_count].map do |arg|
+          @db.resolve_aliases(arg).full_name
         end
+
+        container.instantiations << instantiation
       end
 
       # Returns the count of template arguments expected for a container of

--- a/src/bindgen/processor/sanity_check.cr
+++ b/src/bindgen/processor/sanity_check.cr
@@ -30,6 +30,11 @@ module Bindgen
       # Regular expression describing a method name
       METHOD_NAME_RX = /^[a-z_][A-Za-z0-9_]*[?!=]?$/
 
+      # Regular expression for a Crystal `Enumerable` typename
+      # TODO: support other Crystal stdlib types (which might not correspond to
+      # any C++ type at all)
+      ENUMERABLE_RX = /^Enumerable(?:\([A-Za-z0-9_():*]*\))?$/
+
       # A binding error
       struct Error
         # The node this error occured at
@@ -189,6 +194,8 @@ module Bindgen
           true
         elsif @db.try_or(expr.type, false, &.builtin?)
           true # Crystal built-in
+        elsif expr.type_name.matches?(ENUMERABLE_RX)
+          true # Containers
         else   # Do a full look-up otherwise
           Graph::Path.from(expr.type_name).lookup(base) != nil
         end

--- a/src/bindgen/type_database.cr
+++ b/src/bindgen/type_database.cr
@@ -280,7 +280,7 @@ module Bindgen
       while type
         decayed_type = type.decayed
 
-        if found = @types[resolve_aliases(type.full_name).full_name]?
+        if found = @types[resolve_aliases(type).full_name]?
           if decayed_type && (parent = @types[decayed_type.full_name]?)
             found = parent.merge(found)
           end


### PR DESCRIPTION
This PR adds support for two kinds of aliases:

* Aliased names inside template type arguments, e.g. `QVector<QRgb>` now resolves properly to `QVector<unsigned int>`. Both C++ types will use the same wrapper, so the former container is no longer instantiated separately, as required by #102.
* Aliases to container instantiations, e.g. `QObjectList` now resolves properly to `QList<QObject *>`. Consequently, the wrapper for `QObject::children()` will no longer return a raw pointer to the container after this PR, as long as the appropriate alias is defined in the config file:
  ```yaml
  types:
    QObjectList: { alias_for: "QList<QObject *>" }
  ```

Due to recent changes, the type database now has separate rule entries for actual C++ containers (e.g. `QList<QWindow *>`) and their template-less aliases (e.g. `Container_QList_QWindow_X_`). This shouldn't affect any existing bindings; in particular, typedefs in the C++ wrappers are unaffected because they are populated by `Graph::Alias` instead.