### PR TITLE
Support non-member overloaded operators

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -56,12 +56,9 @@ writer method is created: `setWindowTitle() -> #window_title=`
 
 An overloaded operator is a method which:
 
-1. Appears inside the class definition
-2. Is not a `friend` declaration
-3. Corresponds to a Crystal method in the table below
-
-Both `T` and the return type can be anything; const-ness of the method is not
-considered.
+1. Is either a method, or a non-member function taking a wrapped type by lvalue
+   reference in the first function parameter
+2. Corresponds to a Crystal method in the table below
 
 |C++ operator|Crystal method|
 |-|-|
@@ -87,7 +84,12 @@ considered.
 |`&&(T)`|`and(T)`|
 |`||(T)`|`or(T)`|
 |`[](T)`|`[](T)`|
-|`()(T...)`|`call(*T)`|
+|`()(*T)`|`call(*T)`|
+
+Both `T` and the return type in the table can be any type; const-ness of the
+operator is not considered.  Non-member operators are automatically converted
+into methods in the wrapper classes.  Bindgen always uses the operators
+directly, and never invokes them as regular method calls.
 
 The following C++ operators are ignored: `=(T)`, `<=>(T)`, `&()`, `->()`,
 `->*(T)`, `,(T)`, all conversion operators.

--- a/clang/include/bindgen_ast_consumer.hpp
+++ b/clang/include/bindgen_ast_consumer.hpp
@@ -2,6 +2,7 @@
 #define BINDGEN_AST_CONSUMER_HPP
 
 class RecordMatchHandler;
+class OperatorMatchHandler;
 class EnumMatchHandler;
 class FunctionMatchHandler;
 
@@ -14,17 +15,21 @@ public:
 	void HandleTranslationUnit(clang::ASTContext &ctx) override;
 
 private:
+	clang::ast_matchers::MatchFinder makeBasicMatchFinder();
+	clang::ast_matchers::MatchFinder makeDependentMatchFinder();
+
 	void gatherTypeInfo(clang::ASTContext &ctx);
 	void evaluateMacros(clang::ASTContext &ctx);
 	void serializeAndOutput();
 
 	clang::CompilerInstance &m_compiler;
 	std::vector<std::unique_ptr<RecordMatchHandler>> m_classHandlers;
+	std::vector<std::unique_ptr<OperatorMatchHandler>> m_operatorHandlers;
 	std::vector<std::unique_ptr<EnumMatchHandler>> m_enumHandlers;
 	std::unique_ptr<FunctionMatchHandler> m_functionHandler;
 	Document &m_document;
 	clang::ast_matchers::MatchFinder::MatchFinderOptions m_matchFinderOpts;
-	clang::ast_matchers::MatchFinder m_matchFinder;
+	std::vector<clang::ast_matchers::MatchFinder> m_matchFinders;
 };
 
 #endif // BINDGEN_AST_CONSUMER_HPP

--- a/clang/include/json_stream.hpp
+++ b/clang/include/json_stream.hpp
@@ -112,6 +112,11 @@ public:
 		return m_map[key];
 	}
 
+	V *at(const K &key) {
+		auto it = m_map.find(key);
+		return it != m_map.end() ? &it->second : nullptr;
+	}
+
 	JsonStream &toJson(JsonStream &s) const {
 		bool first = true;
 		s << JsonStream::ObjectBegin;

--- a/clang/include/operator_match_handler.hpp
+++ b/clang/include/operator_match_handler.hpp
@@ -1,0 +1,17 @@
+#ifndef OPERATOR_MATCH_HANDLER_HPP
+#define OPERATOR_MATCH_HANDLER_HPP
+
+class OperatorMatchHandler : public clang::ast_matchers::MatchFinder::MatchCallback {
+public:
+	OperatorMatchHandler(Document &doc, const std::string &name);
+
+	virtual void run(const clang::ast_matchers::MatchFinder::MatchResult &Result) override;
+
+private:
+	bool runOnOperator(Method &m, const clang::FunctionDecl *op);
+
+	Document &m_document;
+	std::string m_className;
+};
+
+#endif // OPERATOR_MATCH_HANDLER_HPP

--- a/clang/src/operator_match_handler.cpp
+++ b/clang/src/operator_match_handler.cpp
@@ -1,0 +1,44 @@
+#include "common.hpp"
+#include "operator_match_handler.hpp"
+#include "type_helper.hpp"
+
+# if defined(__LLVM_VERSION_8)
+  #include "clang_type_name_llvm_8.hpp"
+# else
+  #include "clang_type_name.hpp"
+# endif
+
+OperatorMatchHandler::OperatorMatchHandler(Document &doc, const std::string &name)
+	: m_document(doc), m_className(name)
+{
+}
+
+void OperatorMatchHandler::run(const clang::ast_matchers::MatchFinder::MatchResult &result) {
+	const auto *op = result.Nodes.getNodeAs<clang::FunctionDecl>("operatorDecl");
+	if (!op) return;
+
+	Class *klass = this->m_document.classes.at(this->m_className);
+	if (!klass) return;
+
+	Method m { };
+	if (runOnOperator(m, op)) {
+		klass->methods.push_back(m);
+	}
+}
+
+bool OperatorMatchHandler::runOnOperator(Method &m, const clang::FunctionDecl *op) {
+	clang::ASTContext &ctx = op->getASTContext();
+
+	m.type = Method::Operator;
+	m.name = op->getNameAsString();
+	m.access = clang::AS_public;
+	m.returnType = TypeHelper::qualTypeToType(op->getReturnType(), ctx);
+	TypeHelper::addFunctionParameters(op, m);
+
+	// remove self argument
+	m.className = m.arguments[0].baseName;
+	m.isConst = m.arguments[0].isConst;
+	m.arguments.erase(m.arguments.begin());
+
+	return true;
+}

--- a/spec/integration/basic.cpp
+++ b/spec/integration/basic.cpp
@@ -81,6 +81,50 @@ struct Ops {
   int operator()(bool) const { return 20004; }
 };
 
+struct FreeOps { };
+
+int operator+  (FreeOps &, int x) { return x * 1; }
+int operator-  (FreeOps &, int x) { return x * 2; }
+int operator*  (FreeOps &, int x) { return x * 3; }
+int operator/  (FreeOps &, int x) { return x * 4; }
+int operator%  (FreeOps &, int x) { return x * 5; }
+int operator&  (FreeOps &, int x) { return x * 6; }
+int operator|  (FreeOps &, int x) { return x * 7; }
+int operator^  (FreeOps &, int x) { return x * 8; }
+int operator<< (FreeOps &, int x) { return x * 9; }
+int operator>> (FreeOps &, int x) { return x * 10; }
+int operator&& (FreeOps &, int x) { return x * 11; }
+int operator|| (FreeOps &, int x) { return x * 12; }
+int operator== (FreeOps &, int x) { return x * 13; }
+int operator!= (FreeOps &, int x) { return x * 14; }
+int operator<  (FreeOps &, int x) { return x * 15; }
+int operator>  (FreeOps &, int x) { return x * 16; }
+int operator<= (FreeOps &, int x) { return x * 17; }
+int operator>= (FreeOps &, int x) { return x * 18; }
+
+int operator+= (FreeOps &, int x) { return x * 101; }
+int operator-= (FreeOps &, int x) { return x * 102; }
+int operator*= (FreeOps &, int x) { return x * 103; }
+int operator/= (FreeOps &, int x) { return x * 104; }
+int operator%= (FreeOps &, int x) { return x * 105; }
+int operator&= (FreeOps &, int x) { return x * 106; }
+int operator|= (FreeOps &, int x) { return x * 107; }
+int operator^= (FreeOps &, int x) { return x * 108; }
+int operator<<=(FreeOps &, int x) { return x * 109; }
+int operator>>=(FreeOps &, int x) { return x * 110; }
+
+//  auto operator<=>(const FreeOps &, const FreeOps &) = default;
+
+int operator+(FreeOps &) { return 10001; }
+int operator-(FreeOps &) { return 10002; }
+int operator*(FreeOps &) { return 10003; }
+int operator~(FreeOps &) { return 10004; }
+int operator!(FreeOps &) { return 10005; }
+int operator++(FreeOps &) { return 10006; }
+int operator--(FreeOps &) { return 10007; }
+int operator++(FreeOps &, int) { return 10008; }
+int operator--(FreeOps &, int) { return 10009; }
+
 class TypeConversion {
 public:
 

--- a/spec/integration/basic.yml
+++ b/spec/integration/basic.yml
@@ -5,6 +5,7 @@
 classes:
   Adder: AdderWrap
   Ops: Ops
+  FreeOps: FreeOps
   ImplicitConstructor: ImplicitConstructor
   Aggregate: Aggregate
   PrivateConstructor: PrivateConstructor

--- a/spec/integration/basic_spec.cr
+++ b/spec/integration/basic_spec.cr
@@ -12,7 +12,7 @@ describe "a basic C++ wrapper" do
           Test::AdderWrap.new(4).sum(5).should eq(9)
         end
 
-        it "supports member operators" do
+        it "supports member operator overloading" do
           subject = Test::Ops.new
 
           (subject +   1).should eq(1)
@@ -60,6 +60,50 @@ describe "a basic C++ wrapper" do
           subject.call(0).should eq(20002)
           subject.call(0, 0).should eq(20003)
           subject.call(false).should eq(20004)
+        end
+
+        it "supports non-member operator overloading" do
+          subject = Test::FreeOps.new
+
+          (subject +   1).should eq(1)
+          (subject -   2).should eq(4)
+          (subject *   3).should eq(9)
+          (subject /   4).should eq(16)
+          (subject %   5).should eq(25)
+          (subject &   6).should eq(36)
+          (subject |   7).should eq(49)
+          (subject ^   8).should eq(64)
+          (subject <<  9).should eq(81)
+          (subject >> 10).should eq(100)
+          subject.and(11).should eq(121)
+          subject.or(12).should eq(144)
+          (subject == 13).should eq(169)
+          (subject != 14).should eq(196)
+          (subject <  15).should eq(225)
+          (subject >  16).should eq(256)
+          (subject <= 17).should eq(289)
+          (subject >= 18).should eq(324)
+
+          subject.add!(1).should eq(101)
+          subject.sub!(2).should eq(204)
+          subject.mul!(3).should eq(309)
+          subject.div!(4).should eq(416)
+          subject.mod!(5).should eq(525)
+          subject.bit_and!(6).should eq(636)
+          subject.bit_or!(7).should eq(749)
+          subject.bit_xor!(8).should eq(864)
+          subject.lshift!(9).should eq(981)
+          subject.rshift!(10).should eq(1100)
+
+          (+subject).should eq(10001)
+          (-subject).should eq(10002)
+          subject.deref.should eq(10003)
+          (~subject).should eq(10004)
+          subject.not.should eq(10005)
+          subject.succ!.should eq(10006)
+          subject.pred!.should eq(10007)
+          subject.post_succ!.should eq(10008)
+          subject.post_pred!.should eq(10009)
         end
       end
 


### PR DESCRIPTION
Wraps overloaded operators that are not instance methods, as long as their first parameter accepts a wrapped type by (non-const or const) lvalue reference. The operators are transformed into methods by the Clang parser entirely; it makes no differences to Bindgen whether a given operator was defined as a method or not.

On Qt5.cr this mainly affects the geometric object types (`QLine`, `QRect`, `QPolygon`, `QTransform`, and so on).