### PR TITLE
Wrap C++ classes so that the destructor is called.

### DIFF
--- a/TEMPLATE.yml
+++ b/TEMPLATE.yml
@@ -19,12 +19,16 @@ module: MyStuff
 # or `boehmgc-c` for pure C.
 #
 # Don't worry too much about this setting at first.
+# NOTE: if you wrap C++ classes, you probably have to add `-lgccpp` to
+# `library` below.
 cookbook: boehmgc-cpp # Default!
 
 # Defines the `ld_flags` value for the `@[Link]` directive of the generated `lib`.
 # `%` will be replaced by the path to the base-directory of your project,
 # relative to the path of the generated `.cr` file.
-library: "%/ext/binding.a"
+# The `-lgccpp` flag is necessary if you wrap C++ classes and use the
+# boehmgc-cpp cookbook.
+library: "%/ext/binding.a -lgccpp"
 
 # Processors pipeline.  See `README.md` for details on each.
 # Defaults to the following:

--- a/assets/bindgen_helper.hpp
+++ b/assets/bindgen_helper.hpp
@@ -104,5 +104,11 @@ struct CrystalProc {
   }
 };
 
+template <typename T>
+struct CrystalGCWrapper: public T, public gc_cleanup
+{
+  using T::T;
+};
+
 #endif // __cplusplus
 #endif // BINDGEN_HELPER_HPP

--- a/src/bindgen/cpp/cookbook.cr
+++ b/src/bindgen/cpp/cookbook.cr
@@ -167,7 +167,7 @@ module Bindgen
     # Configuration name is `boehmgc-cpp`, aliased as `cpp` for convenience.
     class BoehmGcCppCookbook < BareCppCookbook
       def constructor_name(method_name : String, class_name : String) : String?
-        "new (UseGC) #{class_name}"
+        "new (UseGC) CrystalGCWrapper<#{class_name}>"
       end
 
       def value_to_pointer(type : String) : String?


### PR DESCRIPTION
All C++ class instances are wrapped in a `CrystalGCWrapper` class
that ensures that the garbage collector calls the destructor.

Fixes issue #86.