### PR TITLE
Do not build C++ parts in parallel.

### DIFF
--- a/tool.sh
+++ b/tool.sh
@@ -14,7 +14,7 @@ SOURCE_FILE="$BASE/src/bindgen.cr"
 function print_clang_error {
   echo "  Bindgen requires a full installation of Clang, its libraries and development"
   echo "  headers.  Please install these first, and restart this script."
-  echo "  You can also manually run 'cmake . && make -j' in clang/ for debugging this issue."
+  echo "  You can also manually run 'cmake . && make' in clang/ for debugging this issue."
   echo "  Full path to clang/: $CLANG_DIR"
 
   exit 1
@@ -23,7 +23,7 @@ function print_clang_error {
 if [ ! -f "$CLANG_DIR/parser" ]; then
   echo "** clang/parser not found.  Building now."
   cd "$CLANG_DIR"
-  ( cmake . && make -j ) || print_clang_error
+  ( cmake . && make ) || print_clang_error
   cd -
 fi
 


### PR DESCRIPTION
By default the C++ files of the parser should not be compiled in
parallel because this easily uses up all the available system memory.
The number of files is not that large anyway, so in most cases it
should not matter.

This actually happened to me several times.