### PR TITLE
Fix non-pointer constructors for struct like types.

### DIFF
--- a/assets/bindgen_helper.hpp
+++ b/assets/bindgen_helper.hpp
@@ -110,5 +110,17 @@ struct CrystalGCWrapper: public T, public gc_cleanup
   using T::T;
 };
 
+/// A simple wrapper around a non-pointer type that allows a single
+/// dereference operation.
+template <typename T>
+struct bg_deref {
+  T data;
+
+  template<typename... Args>
+  bg_deref(Args&&... args) : data(std::forward<Args>(args)...) {}
+
+  T operator*() && { return std::move(data); }
+};
+
 #endif // __cplusplus
 #endif // BINDGEN_HELPER_HPP

--- a/src/bindgen/cpp/method_name.cr
+++ b/src/bindgen/cpp/method_name.cr
@@ -28,7 +28,7 @@ module Bindgen
         case type
         when .any_constructor?
           if type_copied?(method.class_name)
-            method.class_name
+            "bg_deref<#{method.class_name}>"
           else # Support shadow sub-classing.
             name = class_name_for_new(method.class_name)
             @db.cookbook.constructor_name(method.name, name)

--- a/src/bindgen/crystal/argument.cr
+++ b/src/bindgen/crystal/argument.cr
@@ -33,7 +33,7 @@ module Bindgen
           type: klass_type,
           type_name: type_name,
           name: "_self_",
-          call: "self",
+          call: @db.try_or(klass_type, false, &.kind.struct?) ? "pointerof(@unwrap)" : "self",
           reference: false,
           pointer: 1, # It's always a pointer
         )

--- a/src/bindgen/generator/crystal.cr
+++ b/src/bindgen/generator/crystal.cr
@@ -31,8 +31,9 @@ module Bindgen
         scope = "private" if klass.origin.private?
         prefix = "abstract" if klass.abstract?
         suffix = "< #{klass.base_class}" if klass.base_class
+        isstruct = @db.try_or(klass.origin.name, false, &.kind.struct?)
 
-        code_block scope, prefix, "class", klass.name, suffix do
+        code_block scope, prefix, isstruct ? "struct" : "class", klass.name, suffix do
           write_included_modules(klass.included_modules)
           write_instance_variables(klass.instance_variables)
           super

--- a/src/bindgen/processor/crystal_wrapper.cr
+++ b/src/bindgen/processor/crystal_wrapper.cr
@@ -51,7 +51,8 @@ module Bindgen
         logger.trace { "add_to_unsafe_method #{klass.diagnostics_path}" }
 
         to_unsafe = CallBuilder::CrystalToUnsafe.new(@db)
-        call = to_unsafe.build(klass.origin, unwrap.pointer < 1)
+        isstruct = @db.try_or(klass.origin.name, false, &.kind.struct?)
+        call = to_unsafe.build(klass.origin, unwrap.pointer < 1 && !isstruct)
 
         host = klass.platform_specific(PLATFORM)
 


### PR DESCRIPTION
The goal of this PR is to support "struct-like", i.e. value-like, *classes*. An example are classes like `QPoint` or `QSize` from Qt. These types are effectively small pass-by-value structs. The current bindgen implementation generates fully heap-allocated classes for them. However, this puts huge pressure on the memory allocator/garbage collector if used in a tight loop, e.g. using `QPoint` in a `paint_event` (and sometimes using theses classes is obligatory). For this reason the current qt5.cr implementation has a *manual* wrapper around `QPoint` (but not `QRect`, `QSize`, `QLine`).

Bindgen is actually able to generate wrapper code for structs but not for methods (especially constructors) within those structs. The purpose of this PR is to handle this case. The following important changes are made:
1. The bindgen parser always assumes that a constructor expression for some class returns a pointer. This is true for the typical "new ClassName(...)" construction, but not for structs. As a consequence the generator will (falsely) add a deference operator such that the final construction code in the binding function has the form `return *(QPoint(...))`. This problem is not easy to solve because of the architecture of bindgen: the parser itself replaces the return type of a constructor from "none" (a constructor returns nothing) to "Class *". This is enforced in the parsing code. All subsequent steps (processors and code generators) all see the modified return value and have no (easy) way to determine that the original return value has been "none". The solution is as follows: the code generated for the construction expression is wrapped in an `bg_deref` template class (new in bindgen_helper.hpp) that supports the additional dereferencing operator (the above example is changed to `return *(bg_deref<QPoint>(...))` which is now valid). The reason why we add `bg_deref` instead of just removing the `*` is that it is much easier to modify the generator code to produce additional code when the `QPoint(...)` constructor call is generated, but the `*` is created at some completely different position.
2. The generated crystal code is also modified. First, the generated wrapper class is now "struct Class" instead of "class Class". This is done by checking if the to-be-wrapped-class is configured with `kind: Struct`. Second, the binding code has one problem: typically all parameters of that type are passed by value with one exception: the `self` argument of a method. Because only these arguments are passed by pointer but all others are passed by value, the wrapper code cannot rely on the `to_unsafe` method anymore (it would need to have two different return types). Therefore the wrapper code is modified to pass `pointerof(@unwrap)` instead of `self` for the self argument.

Although these changes work, it would certainly be better to support pass-by-value classes directly. They currently feel more like a hack. The advantage is that the number of changed lines is rather small.