### PR TITLE
Unify methods

### DIFF
--- a/src/bindgen/parser/method.cr
+++ b/src/bindgen/parser/method.cr
@@ -648,6 +648,17 @@ module Bindgen
         )
       end
 
+      # Unify arguments of this and another method.
+      #
+      # Modifies the argument list of this method.
+      def merge_args!(other : Method)
+        args = [] of Argument
+
+        @arguments.size.times do |i|
+          @arguments[i] = @arguments[i].merge(other.arguments[i])
+        end
+      end
+
       # Performs type substitution on the argument and return types of this
       # method using the given *replacements*.
       def substitute_type(replacements : Hash(String, Parser::Type)) : Method


### PR DESCRIPTION
This fixes [issue 48 of qt5.cr](https://github.com/Papierkorb/qt5.cr/issues/48).

The implementation addresses the problem described in this bug report. The argument lists of inherited virtual methods are unified so that possible missing default argument (or nilability) is preserved through inheritance. This ensures that the types do not differ by nilability in derived classes (which is forbidden in Crystal).